### PR TITLE
Fix for R Tools version check.

### DIFF
--- a/r-project_rtools/BuildTurboImage.ps1
+++ b/r-project_rtools/BuildTurboImage.ps1
@@ -57,13 +57,32 @@ $URL = 'https://cran.r-project.org/bin/windows/Rtools/'
 
 $Page = curl $URL -UseBasicParsing
 
-$LatestVersionLink =  ($Page.Links | Where-Object {$_.outerHTML -like "*RTools*"}).href[0]
-$LatestVersion = ($LatestVersionLink -Split '/')[0]
+# Split up the download link table rows and look for the R-release version.
+$TableRows = $Page.Content -split "<tr>"
+
+# Find the table row with the release version of R Tools.
+$LatestVersion = ""
+$LatestVersionLink = ""
+ForEach ($TableRow in $TableRows)
+{
+
+  If ($TableRow -like "*R-release*") 
+  {
+   # Parse the <a href=""> link for the release version.
+   $LatestVersionLink = (($TableRows[2] -split "<a href=""") -split """>")[1]
+   
+   # Parse the link segment for the latest version. Used in assembling the download link.
+   $LatestVersion = ($LatestVersionLink -split "/")[0]
+   
+   break
+  }
+}
 
 $Page2 = curl ($URL + $LatestVersionLink) -UseBasicParsing
 
-$DownloadLink = ($Page2.Links | Where-Object { $_.href -like '*.exe*' } | Select-Object -ExpandProperty href)[0]
-$DownloadLink = $URL + $LatestVersion + "/" + $DownloadLink 
+# Get the right link for the installer executable. Note duplicate Rtools installer links (sources) and arm64 installer in the next release.
+$DownloadLink = ($Page2.Links | Where-Object { ($_.outerHTML -like '*>Rtools* installer<*') -and ($_.href -like '*.exe') }) | Select-Object -ExpandProperty href
+$DownloadLink = $URL + $LatestVersion + "/" + $DownloadLink
 
 # Name of the downloaded installer file
 $InstallerName = Split-Path -Path $DownloadLink -Leaf

--- a/r-project_rtools/BuildTurboImage.ps1
+++ b/r-project_rtools/BuildTurboImage.ps1
@@ -62,7 +62,7 @@ $LatestVersion = ($LatestVersionLink -Split '/')[0]
 
 $Page2 = curl ($URL + $LatestVersionLink) -UseBasicParsing
 
-$DownloadLink = $Page2.Links | Where-Object { $_.href -like '*.exe*' } | Select-Object -ExpandProperty href
+$DownloadLink = ($Page2.Links | Where-Object { $_.href -like '*.exe*' } | Select-Object -ExpandProperty href)[0]
 $DownloadLink = $URL + $LatestVersion + "/" + $DownloadLink 
 
 # Name of the downloaded installer file

--- a/r-project_rtools/VersionCheck.ps1
+++ b/r-project_rtools/VersionCheck.ps1
@@ -20,7 +20,7 @@ $LatestVersion = ($LatestVersionLink -Split '/')[0]
 
 $Page2 = curl ($URL + $LatestVersionLink) -UseBasicParsing
 
-$DownloadLink = $Page2.Links | Where-Object { $_.href -like '*.exe*' } | Select-Object -ExpandProperty href
+$DownloadLink = ($Page2.Links | Where-Object { $_.href -like '*.exe*' } | Select-Object -ExpandProperty href)[0]
 $DownloadLink = $URL + $LatestVersion + "/" + $DownloadLink 
 
 # Name of the downloaded installer file

--- a/r-project_rtools/VersionCheck.ps1
+++ b/r-project_rtools/VersionCheck.ps1
@@ -15,13 +15,33 @@ $URL = 'https://cran.r-project.org/bin/windows/Rtools/'
 
 $Page = curl $URL -UseBasicParsing
 
-$LatestVersionLink =  ($Page.Links | Where-Object {$_.outerHTML -like "*RTools*"}).href[0]
-$LatestVersion = ($LatestVersionLink -Split '/')[0]
+# Split up the download link table rows and look for the R-release version.
+$TableRows = $Page.Content -split "<tr>"
+
+# Find the table row with the release version of R Tools.
+$LatestVersion = ""
+$LatestVersionLink = ""
+ForEach ($TableRow in $TableRows)
+{
+
+  If ($TableRow -like "*R-release*") 
+  {
+   # Parse the <a href=""> link for the release version.
+   $LatestVersionLink = (($TableRows[2] -split "<a href=""") -split """>")[1]
+   
+   # Parse the link segment for the latest version. Used in assembling the download link.
+   $LatestVersion = ($LatestVersionLink -split "/")[0]
+   
+   break
+  }
+}
+
 
 $Page2 = curl ($URL + $LatestVersionLink) -UseBasicParsing
 
-$DownloadLink = ($Page2.Links | Where-Object { $_.href -like '*.exe*' } | Select-Object -ExpandProperty href)[0]
-$DownloadLink = $URL + $LatestVersion + "/" + $DownloadLink 
+# Get the right link for the installer executable. Note duplicate Rtools installer links (sources) and arm64 installer in the next release.
+$DownloadLink = ($Page2.Links | Where-Object { ($_.outerHTML -like '*>Rtools* installer<*') -and ($_.href -like '*.exe') }) | Select-Object -ExpandProperty href
+$DownloadLink = $URL + $LatestVersion + "/" + $DownloadLink
 
 # Name of the downloaded installer file
 $InstallerName = Split-Path -Path $DownloadLink -Leaf


### PR DESCRIPTION
Looks like the RTools download page added a link for the arm64 installer. Update version check and installer download logic.