### PR TITLE
Fix Chrome version detection.

### DIFF
--- a/google_chrome-x64/BuildTurboImage.ps1
+++ b/google_chrome-x64/BuildTurboImage.ps1
@@ -53,6 +53,7 @@ CheckHubVersion
 WriteLog "Downloading the latest MSI installer."
 
 # Get installer link for latest version
+## Simplified link is https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi. However, our link disables browser usage stats and installs for all users.
 $DownloadLink = "https://dl.google.com/tag/s/appguid%3D%7B8A69D345-D564-463C-AFF1-A69D9E530F96%7D%26iid%3D%7B2CC0992A-8A31-8D75-167C-5C46238DE706%7D%26lang%3Den%26browser%3D5%26usagestats%3D0%26appname%3DGoogle%2520Chrome%26needsadmin%3Dtrue%26ap%3Dx64-stable-statsdef_0%26brand%3DGCEW/dl/chrome/install/googlechromestandaloneenterprise64.msi"
 
 # Name of the downloaded installer file

--- a/google_chrome-x64/VersionCheck.ps1
+++ b/google_chrome-x64/VersionCheck.ps1
@@ -10,14 +10,29 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
+# This method does not work because Google's Version History API latest returned version does not match their MSI download version.
 # Define the URL
-$chromeVersionURL = "https://versionhistory.googleapis.com/v1/chrome/platforms/win/channels/stable/versions"
-
+# $chromeVersionURL = "https://versionhistory.googleapis.com/v1/chrome/platforms/win64/channels/stable/versions"
 # Make a GET request
-$response = Invoke-RestMethod -Uri $chromeVersionURL -UseBasicParsing
-
+# $response = Invoke-RestMethod -Uri $chromeVersionURL -UseBasicParsing
 # Extract the latest version
-$LatestWebVersion = $response.versions[0].version
+# $LatestWebVersion = $response.versions[0].version
+
+# Have to download the installer and check its meta for the actual version.
+$DownloadLink = "https://dl.google.com/tag/s/appguid%3D%7B8A69D345-D564-463C-AFF1-A69D9E530F96%7D%26iid%3D%7B2CC0992A-8A31-8D75-167C-5C46238DE706%7D%26lang%3Den%26browser%3D5%26usagestats%3D0%26appname%3DGoogle%2520Chrome%26needsadmin%3Dtrue%26ap%3Dx64-stable-statsdef_0%26brand%3DGCEW/dl/chrome/install/googlechromestandaloneenterprise64.msi"
+
+# Name of the downloaded installer file
+$InstallerName = "googlechromestandaloneenterprise.msi"
+
+# Installer file object
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+# Read the comments field from the file meta using the Windows Shell object.
+# The MSI installer lists a different version under the MSI ProductVersion field that cannot be converted back to the Chrome version.
+$InstallerFolder = (New-Object -ComObject Shell.Application).NameSpace((Split-Path $Installer))
+## Set property index to 24 to get the Comments file meta field.
+## Split the comments at the Copyright part and grab the first string for the version.
+$LatestWebVersion = ($InstallerFolder.GetDetailsOf($InstallerFolder.parsename((Split-Path -Leaf $Installer)),24) -split " Copyright")[0]
 $LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
 
 WriteLog "WebVersion=$LatestWebVersion"

--- a/google_chrome/BuildTurboImage.ps1
+++ b/google_chrome/BuildTurboImage.ps1
@@ -53,6 +53,7 @@ CheckHubVersion
 WriteLog "Downloading the latest MSI installer."
 
 # Get installer link for latest version
+## Simplified link is https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi. However, our link disables browser usage stats and installs for all users.
 $DownloadLink = "https://dl.google.com/tag/s/appguid={00000000-0000-0000-0000-000000000000}&iid={00000000-0000-0000-0000-000000000000}&lang=$language&browser=3&usagestats=0&appname=Google%20Chrome&installdataindex=defaultbrowser&needsadmin=prefers/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi"
 
 # Name of the downloaded installer file

--- a/google_chrome/VersionCheck.ps1
+++ b/google_chrome/VersionCheck.ps1
@@ -10,14 +10,29 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
+# This method does not work because Google's Version History API latest returned version does not match their MSI download version.
 # Define the URL
-$chromeVersionURL = "https://versionhistory.googleapis.com/v1/chrome/platforms/win/channels/stable/versions"
-
+# $chromeVersionURL = "https://versionhistory.googleapis.com/v1/chrome/platforms/win/channels/stable/versions"
 # Make a GET request
-$response = Invoke-RestMethod -Uri $chromeVersionURL -UseBasicParsing
-
+# $response = Invoke-RestMethod -Uri $chromeVersionURL -UseBasicParsing
 # Extract the latest version
-$LatestWebVersion = $response.versions[0].version
+# $LatestWebVersion = $response.versions[0].version
+
+# Have to download the installer and check its meta for the actual version.
+$DownloadLink = "https://dl.google.com/tag/s/appguid={00000000-0000-0000-0000-000000000000}&iid={00000000-0000-0000-0000-000000000000}&lang=$language&browser=3&usagestats=0&appname=Google%20Chrome&installdataindex=defaultbrowser&needsadmin=prefers/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi"
+
+# Name of the downloaded installer file
+$InstallerName = "googlechromestandaloneenterprise.msi"
+
+# Installer file object
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+# Read the comments field from the file meta using the Windows Shell object.
+# The MSI installer lists a different version under the MSI ProductVersion field that cannot be converted back to the Chrome version.
+$InstallerFolder = (New-Object -ComObject Shell.Application).NameSpace((Split-Path $Installer))
+## Set property index to 24 to get the Comments file meta field.
+## Split the comments at the Copyright part and grab the first string for the version.
+$LatestWebVersion = ($InstallerFolder.GetDetailsOf($InstallerFolder.parsename((Split-Path -Leaf $Installer)),24) -split " Copyright")[0]
 $LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
 
 WriteLog "WebVersion=$LatestWebVersion"


### PR DESCRIPTION
The Google Version API does not match the download version for Chrome, so can't use that.
Just download the MSI and check the comments file meta field since the MSI ProductVersion is incorrect.