### PR TITLE
Fix for vscode bg procs

### DIFF
--- a/microsoft_vscode-x64/SupportFiles/PostCaptureModifications.ps1
+++ b/microsoft_vscode-x64/SupportFiles/PostCaptureModifications.ps1
@@ -4,6 +4,7 @@ $PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\
 # Configure vm settings
 $VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
 $VirtualizationSettings.chromiumSupport = [string]$true
+$VirtualizationSettings.shutdownProcessTree = [string]$true
 
 
 ###############################

--- a/microsoft_vscode/SupportFiles/PostCaptureModifications.ps1
+++ b/microsoft_vscode/SupportFiles/PostCaptureModifications.ps1
@@ -1,6 +1,9 @@
 $PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
 . $PostCaptureFunctionsPath  # Include the script that contains post capture functions
 
+# Configure vm settings
+$VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
+$VirtualizationSettings.shutdownProcessTree = [string]$true
 
 ###############################
 # Edit Named Object Isolation #


### PR DESCRIPTION
Enable shutdown process tree vm setting to fix vscode background processes such as dotnet.exe keeping the container running after you close the vscode window.