### PR TITLE
Refactor version detection and download logic, GlobalBuildScript fixes

### DIFF
--- a/!include/GlobalBuildScript.ps1
+++ b/!include/GlobalBuildScript.ps1
@@ -117,7 +117,10 @@ Function GetHubRevisions($HubOrg,$URL) {
 # Get Current Hub Version of application
 Function GetCurrentHubVersion($HubOrg,$URL) {
     $response = GetHubRevisions $HubOrg $URL
-    $VersionList = $response.tags| Sort-Object { [System.Version]$_ } -Descending
+    $VersionList = $response.tags | Sort-Object {
+        $parts = ($_ -split '\.').Count
+        if ($parts -eq 1) { [System.Version]("$_" + ".0") } else { [System.Version]$_ }
+    } -Descending
     $LatestHubVer = $VersionList | Select-Object -First 1
     $LatestHubVer = RemoveTrailingZeros $LatestHubVer
     WriteLog "HubVersion=$LatestHubVer"

--- a/!include/GlobalBuildScript.ps1
+++ b/!include/GlobalBuildScript.ps1
@@ -93,7 +93,7 @@ Function GetHubRevisions($HubOrg,$URL) {
         $URL = $PushURL
     }
     # Split the repo parts into owner and name values
-    $repoOwner, $repoName = $HubOrg -split "_"
+    $repoOwner, $repoName = $HubOrg -split "[_/]", 2
     WriteLog "Getting the current $HubOrg version from $URL"
     
     # Get token from API Key
@@ -226,7 +226,7 @@ function RemoveTrailingZeros {
 	# Find first non-zero index
 	$index = 0
     $len = $verArray.length
-	ForEach ($v in $verArray[0..$len]) {
+	ForEach ($v in $verArray[0..($len-1)]) {
 	  if ([int]$v -ne 0) {
 		$index = $verArray.IndexOf($v)
 		break
@@ -234,7 +234,7 @@ function RemoveTrailingZeros {
 	}
 	
 	# Copy array from first non-zero index to end.
-	$verArrayTrimmed = $verArray[$index..($verArray.length)]
+	$verArrayTrimmed = $verArray[$index..($verArray.length - 1)]
 	# Reverse back to normal version order
 	[array]::Reverse($verArrayTrimmed)
     If ($verArrayTrimmed.Length -eq 1) {

--- a/7-zip_7-zip-x64/BuildTurboImage.ps1
+++ b/7-zip_7-zip-x64/BuildTurboImage.ps1
@@ -52,14 +52,10 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest MSI installer."
 
-$Page = curl 'https://www.7-zip.org/download.html' -UseBasicParsing
-
-# Get installer link for latest version
-$LatestInstaller = ($Page.Links | Where-Object {$_.href -like "*-x64.msi"})[0].href
-$DownloadLink = "https://www.7-zip.org/" + $LatestInstaller
-
-# Name of the downloaded installer file
-$InstallerName = $LatestInstaller.Split("/")[1]
+$release = Invoke-RestMethod "https://api.github.com/repos/ip7z/7zip/releases/latest"
+$asset = $release.assets | Where-Object { $_.name -like "*-x64.msi" }
+$DownloadLink = $asset.browser_download_url
+$InstallerName = $asset.name
 
 $Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 

--- a/7-zip_7-zip-x64/VersionCheck.ps1
+++ b/7-zip_7-zip-x64/VersionCheck.ps1
@@ -10,15 +10,8 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-# Get installer link for latest version
 $release = Invoke-RestMethod "https://api.github.com/repos/ip7z/7zip/releases/latest"
-$asset = $release.assets | Where-Object { $_.name -like "*-x64.msi" }
-$DownloadLink = $asset.browser_download_url
-$InstallerName = $asset.name
-$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
-
-$LatestWebVersion = Get-MsiProductVersion "$Installer"
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$LatestWebVersion = RemoveTrailingZeros $release.tag_name
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/7-zip_7-zip-x64/VersionCheck.ps1
+++ b/7-zip_7-zip-x64/VersionCheck.ps1
@@ -11,12 +11,10 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 #############################################
 
 # Get installer link for latest version
-$Page = curl 'https://www.7-zip.org/download.html' -UseBasicParsing
-
-# Get installer link for latest version
-$LatestInstaller = ($Page.Links | Where-Object {$_.href -like "*.msi"})[0].href
-$DownloadLink = "https://www.7-zip.org/" + $LatestInstaller
-$InstallerName = $LatestInstaller.Split("/")[1]
+$release = Invoke-RestMethod "https://api.github.com/repos/ip7z/7zip/releases/latest"
+$asset = $release.assets | Where-Object { $_.name -like "*-x64.msi" }
+$DownloadLink = $asset.browser_download_url
+$InstallerName = $asset.name
 $Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 
 $LatestWebVersion = Get-MsiProductVersion "$Installer"

--- a/7-zip_7-zip/BuildTurboImage.ps1
+++ b/7-zip_7-zip/BuildTurboImage.ps1
@@ -52,14 +52,10 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest MSI installer."
 
-$Page = curl 'https://www.7-zip.org/download.html' -UseBasicParsing
-
-# Get installer link for latest version
-$LatestInstaller = ($Page.Links | Where-Object {$_.href -like "*.msi"})[1].href
-$DownloadLink = "https://www.7-zip.org/" + $LatestInstaller
-
-# Name of the downloaded installer file
-$InstallerName = $LatestInstaller.Split("/")[1]
+$release = Invoke-RestMethod "https://api.github.com/repos/ip7z/7zip/releases/latest"
+$asset = $release.assets | Where-Object { $_.name -like "*.msi" -and $_.name -notlike "*-x64.msi" }
+$DownloadLink = $asset.browser_download_url
+$InstallerName = $asset.name
 
 $Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 

--- a/7-zip_7-zip/VersionCheck.ps1
+++ b/7-zip_7-zip/VersionCheck.ps1
@@ -11,12 +11,10 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 #############################################
 
 # Get installer link for latest version
-$Page = curl 'https://www.7-zip.org/download.html' -UseBasicParsing
-
-# Get installer link for latest version
-$LatestInstaller = ($Page.Links | Where-Object {$_.href -like "*.msi"})[1].href
-$DownloadLink = "https://www.7-zip.org/" + $LatestInstaller
-$InstallerName = $LatestInstaller.Split("/")[1]
+$release = Invoke-RestMethod "https://api.github.com/repos/ip7z/7zip/releases/latest"
+$asset = $release.assets | Where-Object { $_.name -like "*.msi" -and $_.name -notlike "*-x64.msi" }
+$DownloadLink = $asset.browser_download_url
+$InstallerName = $asset.name
 $Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 
 $LatestWebVersion = Get-MsiProductVersion "$Installer"

--- a/7-zip_7-zip/VersionCheck.ps1
+++ b/7-zip_7-zip/VersionCheck.ps1
@@ -10,15 +10,8 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-# Get installer link for latest version
 $release = Invoke-RestMethod "https://api.github.com/repos/ip7z/7zip/releases/latest"
-$asset = $release.assets | Where-Object { $_.name -like "*.msi" -and $_.name -notlike "*-x64.msi" }
-$DownloadLink = $asset.browser_download_url
-$InstallerName = $asset.name
-$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
-
-$LatestWebVersion = Get-MsiProductVersion "$Installer"
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$LatestWebVersion = RemoveTrailingZeros $release.tag_name
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/dymo_dymoconnect/BuildTurboImage.ps1
+++ b/dymo_dymoconnect/BuildTurboImage.ps1
@@ -61,15 +61,17 @@ turbo run turbo/headless-extractor --using=google/chrome-x64 --isolate=merge-use
 
 $links = Get-Content -Path "$outputdir\links.txt"
 
-# Define a regular expression pattern
-$pattern = '.*/dymo/Software/Win/.*'
-
-# Filter and output lines containing matching links
+# Filter links for the x64 Windows installer
 foreach ($line in $links) {
-    if ($line -match $pattern) {
-        $DownloadLink = $line  # Directly use the matching URL
-        break # get out after first match
+    if ($line -match 'DCDWIN.*X64.*\.exe') {
+        $DownloadLink = $line
+        break
     }
+}
+
+if (-not $DownloadLink) {
+    WriteLog "ERROR: No DYMO installer link found. Check if the download page structure changed."
+    exit 1
 }
 
 $InstallerName = $DownloadLink.split("/")[-1]

--- a/dymo_dymoconnect/BuildTurboImage.ps1
+++ b/dymo_dymoconnect/BuildTurboImage.ps1
@@ -52,29 +52,16 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-# Use the headless-extractor to get the download link
-$url = "https://www.dymo.com/support?cfid=user-guide"
-$outputdir = "$DownloadPath\links"
-turbo config --domain=turbo.net
-turbo pull turbo/headless-extractor
-turbo run turbo/headless-extractor --using=google/chrome-x64 --isolate=merge-user --startup-file=powershell -- C:\extractor\Extract.ps1 -OutputDir $outputdir -Url $url -DOM -ExtractLinks
+$versions = Invoke-RestMethod "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/d/DYMO/DYMOConnect"
+$latestVersion = ($versions | Sort-Object { [version]$_.name } -Descending | Select-Object -First 1).name
 
-$links = Get-Content -Path "$outputdir\links.txt"
-
-# Filter links for the x64 Windows installer
-foreach ($line in $links) {
-    if ($line -match 'DCDWIN.*X64.*\.exe') {
-        $DownloadLink = $line
-        break
-    }
-}
-
-if (-not $DownloadLink) {
-    WriteLog "ERROR: No DYMO installer link found. Check if the download page structure changed."
+if (-not $latestVersion) {
+    WriteLog "ERROR: Could not find DYMO Connect version in winget-pkgs."
     exit 1
 }
 
-$InstallerName = $DownloadLink.split("/")[-1]
+$InstallerName = "DCDSetup$latestVersion-X64.exe"
+$DownloadLink = "https://dymoreleasecontent.blob.core.windows.net/dymo-release/DCDWIN/$InstallerName"
 $Installer = Join-Path -Path $DownloadPath -ChildPath $InstallerName
 . curl.exe $DownloadLink -o $Installer
 

--- a/dymo_dymoconnect/VersionCheck.ps1
+++ b/dymo_dymoconnect/VersionCheck.ps1
@@ -19,23 +19,27 @@ turbo run turbo/headless-extractor --using=google/chrome-x64 --isolate=merge-use
 
 $links = Get-Content -Path "$outputdir\links.txt"
 
-# Define a regular expression pattern
-$pattern = '.*/dymo/Software/Win/.*'
-
-# Filter and output lines containing matching links
+# Filter links for the x64 Windows installer
 foreach ($line in $links) {
-    if ($line -match $pattern) {
-        $DownloadLink = $line  # Directly use the matching URL
-        break # get out after first match
+    if ($line -match 'DCDWIN.*X64.*\.exe') {
+        $DownloadLink = $line
+        break
     }
 }
 
-$InstallerName = $DownloadLink.split("/")[-1]
-$Installer = Join-Path -Path $DownloadPath -ChildPath $InstallerName
-. curl.exe $DownloadLink -o $Installer
+if (-not $DownloadLink) {
+    WriteLog "ERROR: No DYMO installer link found. Check if the download page structure changed."
+    exit 1
+}
 
-$LatestWebVersion = Get-VersionFromExe $Installer
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+# Extract version from filename: DCDSetup1.6.0.36-X64.exe -> 1.6.0.36
+$InstallerName = $DownloadLink.split("/")[-1]
+if ($InstallerName -match 'DCDSetup([\d.]+)') {
+    $LatestWebVersion = RemoveTrailingZeros $Matches[1]
+} else {
+    WriteLog "ERROR: Could not parse version from installer filename: $InstallerName"
+    exit 1
+}
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/dymo_dymoconnect/VersionCheck.ps1
+++ b/dymo_dymoconnect/VersionCheck.ps1
@@ -10,36 +10,14 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-# Use the headless-extractor to get the download link
-$url = "https://www.dymo.com/support?cfid=user-guide"
-$outputdir = "$DownloadPath\links"
-turbo config --domain=turbo.net
-turbo pull turbo/headless-extractor
-turbo run turbo/headless-extractor --using=google/chrome-x64 --isolate=merge-user --startup-file=powershell -- C:\extractor\Extract.ps1 -OutputDir $outputdir -Url $url -DOM -ExtractLinks
+$versions = Invoke-RestMethod "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/d/DYMO/DYMOConnect"
+$latestVersion = ($versions | Sort-Object { [version]$_.name } -Descending | Select-Object -First 1).name
 
-$links = Get-Content -Path "$outputdir\links.txt"
-
-# Filter links for the x64 Windows installer
-foreach ($line in $links) {
-    if ($line -match 'DCDWIN.*X64.*\.exe') {
-        $DownloadLink = $line
-        break
-    }
-}
-
-if (-not $DownloadLink) {
-    WriteLog "ERROR: No DYMO installer link found. Check if the download page structure changed."
+if (-not $latestVersion) {
+    WriteLog "ERROR: Could not find DYMO Connect version in winget-pkgs."
     exit 1
 }
-
-# Extract version from filename: DCDSetup1.6.0.36-X64.exe -> 1.6.0.36
-$InstallerName = $DownloadLink.split("/")[-1]
-if ($InstallerName -match 'DCDSetup([\d.]+)') {
-    $LatestWebVersion = RemoveTrailingZeros $Matches[1]
-} else {
-    WriteLog "ERROR: Could not parse version from installer filename: $InstallerName"
-    exit 1
-}
+$LatestWebVersion = RemoveTrailingZeros $latestVersion
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/git_git/BuildTurboImage.ps1
+++ b/git_git/BuildTurboImage.ps1
@@ -52,18 +52,13 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-$Page = curl 'https://git-scm.com/downloads/win' -UseBasicParsing
-
-# Get installer link for latest version
-$DownloadLink = ($Page.Links | Where-Object {$_.href -like "*64-bit.exe"})[0].href
-
-# Name of the downloaded installer file
-$InstallerName = $DownloadLink.Split("/")[-1]
-
+$release = Invoke-RestMethod "https://api.github.com/repos/git-for-windows/git/releases/latest"
+$asset = $release.assets | Where-Object { $_.name -like "Git-*-64-bit.exe" } | Select-Object -First 1
+$DownloadLink = $asset.browser_download_url
+$InstallerName = $asset.name
 $Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 
-$InstalledVersion = Get-VersionFromExe $Installer
-$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+$InstalledVersion = RemoveTrailingZeros ($InstallerName -split '-')[1]
 
 #########################
 ## Start Turbo Capture ##

--- a/git_git/VersionCheck.ps1
+++ b/git_git/VersionCheck.ps1
@@ -10,18 +10,9 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-$Page = curl 'https://git-scm.com/downloads/win' -UseBasicParsing
-
-# Get installer link for latest version
-$DownloadLink = ($Page.Links | Where-Object {$_.href -like "*64-bit.exe"})[0].href
-
-# Name of the downloaded installer file
-$InstallerName = $DownloadLink.Split("/")[-1]
-
-$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
-
-$LatestWebVersion = Get-VersionFromExe "$Installer"
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$release = Invoke-RestMethod "https://api.github.com/repos/git-for-windows/git/releases/latest"
+$asset = $release.assets | Where-Object { $_.name -like "Git-*-64-bit.exe" } | Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros ($asset.name -split '-')[1]
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/google_chrome-x64/VersionCheck.ps1
+++ b/google_chrome-x64/VersionCheck.ps1
@@ -10,22 +10,8 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-# Have to download the installer and check its meta for the actual version.
-$DownloadLink = "https://dl.google.com/tag/s/appguid%3D%7B8A69D345-D564-463C-AFF1-A69D9E530F96%7D%26iid%3D%7B2CC0992A-8A31-8D75-167C-5C46238DE706%7D%26lang%3Den%26browser%3D5%26usagestats%3D0%26appname%3DGoogle%2520Chrome%26needsadmin%3Dtrue%26ap%3Dx64-stable-statsdef_0%26brand%3DGCEW/dl/chrome/install/googlechromestandaloneenterprise64.msi"
-
-# Name of the downloaded installer file
-$InstallerName = "googlechromestandaloneenterprise.msi"
-
-# Installer file object
-$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
-
-# Read the comments field from the file meta using the Windows Shell object.
-# The MSI installer lists a different version under the MSI ProductVersion field that cannot be converted back to the Chrome version.
-$InstallerFolder = (New-Object -ComObject Shell.Application).NameSpace((Split-Path $Installer))
-## Set property index to 24 to get the Comments file meta field.
-## Split the comments at the Copyright part and grab the first string for the version.
-$LatestWebVersion = ($InstallerFolder.GetDetailsOf($InstallerFolder.parsename((Split-Path -Leaf $Installer)),24) -split " Copyright")[0]
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$release = Invoke-RestMethod "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Windows&num=1"
+$LatestWebVersion = RemoveTrailingZeros $release[0].version
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/google_chrome/VersionCheck.ps1
+++ b/google_chrome/VersionCheck.ps1
@@ -10,22 +10,8 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-# Have to download the installer and check its meta for the actual version.
-$DownloadLink = "https://dl.google.com/tag/s/appguid={00000000-0000-0000-0000-000000000000}&iid={00000000-0000-0000-0000-000000000000}&lang=$language&browser=3&usagestats=0&appname=Google%20Chrome&installdataindex=defaultbrowser&needsadmin=prefers/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi"
-
-# Name of the downloaded installer file
-$InstallerName = "googlechromestandaloneenterprise.msi"
-
-# Installer file object
-$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
-
-# Read the comments field from the file meta using the Windows Shell object.
-# The MSI installer lists a different version under the MSI ProductVersion field that cannot be converted back to the Chrome version.
-$InstallerFolder = (New-Object -ComObject Shell.Application).NameSpace((Split-Path $Installer))
-## Set property index to 24 to get the Comments file meta field.
-## Split the comments at the Copyright part and grab the first string for the version.
-$LatestWebVersion = ($InstallerFolder.GetDetailsOf($InstallerFolder.parsename((Split-Path -Leaf $Installer)),24) -split " Copyright")[0]
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$release = Invoke-RestMethod "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Windows&num=1"
+$LatestWebVersion = RemoveTrailingZeros $release[0].version
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/google_earthpro/BuildTurboImage.ps1
+++ b/google_earthpro/BuildTurboImage.ps1
@@ -52,20 +52,9 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-# Get main download page for application.
-$Page = curl 'https://support.google.com/earth/answer/168344#zippy=%2Cdownload-a-google-earth-pro-direct-installer' -UseBasicParsing
-
-# Get download page for latest version.
-$DownloadLink = ($Page.Links | Where-Object {$_.href -like "*x64.exe"}).href[0]
-
-# Name of the downloaded installer file
-$InstallerName = $DownloadLink.split("/")[-1]
-
-$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
-
-# Get the latest version tag.
-$InstalledVersion = $InstallerName.split("-")[1]
-$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+$DownloadLink = "https://dl.google.com/earth/client/advanced/current/GoogleEarthProWin-x64.exe"
+$InstallerName = "GoogleEarthProWin-x64.exe"
+DownloadInstaller $DownloadLink $DownloadPath $InstallerName | Out-Null
 
 #########################
 ## Start Turbo Capture ##
@@ -85,6 +74,8 @@ CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on i
 ## Customize the application  ##
 ################################
 WriteLog "Performing post-install customizations."
+
+$InstalledVersion = GetVersionFromRegistry "Google Earth Pro"
 
 # Add the registry to prevent tips on startup
 &reg.exe ADD "HKCU\SOFTWARE\Google\Google Earth Pro" /v enableTips /t REG_SZ /d "false" /f

--- a/google_earthpro/VersionCheck.ps1
+++ b/google_earthpro/VersionCheck.ps1
@@ -1,37 +1,6 @@
 Function RunVersionCheck {
 
-#############################################
-## Get the current Hub version for the app ##
-#############################################
-
-$HubVersion = GetCurrentHubVersion $HubOrg
-
-#############################################
-## Get latest version from the vendor site ##
-#############################################
-
-# Get main download page for application.
-$Page = curl 'https://support.google.com/earth/answer/168344#zippy=%2Cdownload-a-google-earth-pro-direct-installer' -UseBasicParsing
-
-# Get download page for latest version.
-$DownloadLink = ($Page.Links | Where-Object {$_.href -like "*x64.exe"}).href[0]
-
-# Name of the downloaded installer file
-$InstallerName = $DownloadLink.split("/")[-1]
-
-$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
-
-# Get the latest version tag.
-$LatestWebVersion = $InstallerName.split("-")[1]
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
-
-WriteLog "WebVersion=$LatestWebVersion"
-
-
-###########################################
-## Compare latest version to hub version ##
-###########################################
-
-Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+    # Version cannot be determined without downloading and installing - skip version check
+    WriteLog "VersionCheckSkipped=downloads"
 
 }

--- a/microsoft_dotnet-aspnet-runtime-x64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-aspnet-runtime-x64/BuildTurboImage.ps1
@@ -52,30 +52,15 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-# Get the latest .NET major version:
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-WriteLog "Latest Stable Version: $LatestStableVersion"
-$LatestMajorVer = ($LatestStableVersion -split '\.')[0]
-WriteLog "Latest Major version: $LatestMajorVer"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[0])
-$LatestVersion = ($LatestVersion -split '<a.*?>|</a>')[1]
-
-$InstalledVersion = RemoveTrailingZeros "$LatestVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-release'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
 
 # We will use the winget image from Turbo.net to download and install this app
 WriteLog "Pulling microsoft/winget from Turbo.net"

--- a/microsoft_dotnet-aspnet-runtime-x64/VersionCheck.ps1
+++ b/microsoft_dotnet-aspnet-runtime-x64/VersionCheck.ps1
@@ -10,27 +10,12 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-Write-Host "Latest Stable Version: $LatestStableVersion"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestWebVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[1])
-$LatestWebVersion = ($LatestWebVersion -split '<a.*?>|</a>')[0]
-
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros $latestStable.'latest-release'
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/microsoft_dotnet-aspnet-runtime/BuildTurboImage.ps1
+++ b/microsoft_dotnet-aspnet-runtime/BuildTurboImage.ps1
@@ -52,30 +52,15 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-# Get the latest .NET major version:
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-WriteLog "Latest Stable Version: $LatestStableVersion"
-$LatestMajorVer = ($LatestStableVersion -split '\.')[0]
-WriteLog "Latest Major version: $LatestMajorVer"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[0])
-$LatestVersion = ($LatestVersion -split '<a.*?>|</a>')[1]
-
-$InstalledVersion = RemoveTrailingZeros "$LatestVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-release'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
 
 # We will use the winget image from Turbo.net to download and install this app
 WriteLog "Pulling microsoft/winget from Turbo.net"

--- a/microsoft_dotnet-aspnet-runtime/VersionCheck.ps1
+++ b/microsoft_dotnet-aspnet-runtime/VersionCheck.ps1
@@ -10,27 +10,12 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-Write-Host "Latest Stable Version: $LatestStableVersion"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestWebVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[1])
-$LatestWebVersion = ($LatestWebVersion -split '<a.*?>|</a>')[0]
-
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros $latestStable.'latest-release'
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/microsoft_dotnet-desktop-runtime-x64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-desktop-runtime-x64/BuildTurboImage.ps1
@@ -52,30 +52,15 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-# Get the latest .NET major version:
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-WriteLog "Latest Stable Version: $LatestStableVersion"
-$LatestMajorVer = ($LatestStableVersion -split '\.')[0]
-WriteLog "Latest Major version: $LatestMajorVer"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[0])
-$LatestVersion = ($LatestVersion -split '<a.*?>|</a>')[1]
-
-$InstalledVersion = RemoveTrailingZeros "$LatestVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-release'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
 
 # We will use the winget image from Turbo.net to download and install this app
 WriteLog "Pulling microsoft/winget from Turbo.net"

--- a/microsoft_dotnet-desktop-runtime-x64/VersionCheck.ps1
+++ b/microsoft_dotnet-desktop-runtime-x64/VersionCheck.ps1
@@ -10,27 +10,12 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-Write-Host "Latest Stable Version: $LatestStableVersion"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestWebVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[1])
-$LatestWebVersion = ($LatestWebVersion -split '<a.*?>|</a>')[0]
-
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros $latestStable.'latest-release'
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/microsoft_dotnet-desktop-runtime/BuildTurboImage.ps1
+++ b/microsoft_dotnet-desktop-runtime/BuildTurboImage.ps1
@@ -52,30 +52,15 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-# Get the latest .NET major version:
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-WriteLog "Latest Stable Version: $LatestStableVersion"
-$LatestMajorVer = ($LatestStableVersion -split '\.')[0]
-WriteLog "Latest Major version: $LatestMajorVer"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[0])
-$LatestVersion = ($LatestVersion -split '<a.*?>|</a>')[1]
-
-$InstalledVersion = RemoveTrailingZeros "$LatestVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-release'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
 
 # We will use the winget image from Turbo.net to download and install this app
 WriteLog "Pulling microsoft/winget from Turbo.net"

--- a/microsoft_dotnet-desktop-runtime/VersionCheck.ps1
+++ b/microsoft_dotnet-desktop-runtime/VersionCheck.ps1
@@ -10,27 +10,12 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-Write-Host "Latest Stable Version: $LatestStableVersion"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestWebVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[1])
-$LatestWebVersion = ($LatestWebVersion -split '<a.*?>|</a>')[0]
-
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros $latestStable.'latest-release'
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/microsoft_dotnet-runtime-x64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-runtime-x64/BuildTurboImage.ps1
@@ -52,30 +52,15 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-# Get the latest .NET major version:
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-WriteLog "Latest Stable Version: $LatestStableVersion"
-$LatestMajorVer = ($LatestStableVersion -split '\.')[0]
-WriteLog "Latest Major version: $LatestMajorVer"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[0])
-$LatestVersion = ($LatestVersion -split '<a.*?>|</a>')[1]
-
-$InstalledVersion = RemoveTrailingZeros "$LatestVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-release'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
 
 # We will use the winget image from Turbo.net to download and install this app
 WriteLog "Pulling microsoft/winget from Turbo.net"

--- a/microsoft_dotnet-runtime-x64/VersionCheck.ps1
+++ b/microsoft_dotnet-runtime-x64/VersionCheck.ps1
@@ -10,27 +10,12 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-Write-Host "Latest Stable Version: $LatestStableVersion"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestWebVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[1])
-$LatestWebVersion = ($LatestWebVersion -split '<a.*?>|</a>')[0]
-
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros $latestStable.'latest-release'
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/microsoft_dotnet-runtime/BuildTurboImage.ps1
+++ b/microsoft_dotnet-runtime/BuildTurboImage.ps1
@@ -52,30 +52,15 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-# Get the latest .NET major version:
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-WriteLog "Latest Stable Version: $LatestStableVersion"
-$LatestMajorVer = ($LatestStableVersion -split '\.')[0]
-WriteLog "Latest Major version: $LatestMajorVer"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[0])
-$LatestVersion = ($LatestVersion -split '<a.*?>|</a>')[1]
-
-$InstalledVersion = RemoveTrailingZeros "$LatestVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-release'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
 
 # We will use the winget image from Turbo.net to download and install this app
 WriteLog "Pulling microsoft/winget from Turbo.net"

--- a/microsoft_dotnet-runtime/VersionCheck.ps1
+++ b/microsoft_dotnet-runtime/VersionCheck.ps1
@@ -10,27 +10,12 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-Write-Host "Latest Stable Version: $LatestStableVersion"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestWebVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[1])
-$LatestWebVersion = ($LatestWebVersion -split '<a.*?>|</a>')[0]
-
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros $latestStable.'latest-release'
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/microsoft_dotnet-sdk-x64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-sdk-x64/BuildTurboImage.ps1
@@ -52,30 +52,15 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-# Get the latest .NET major version:
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-WriteLog "Latest Stable Version: $LatestStableVersion"
-$LatestMajorVer = ($LatestStableVersion -split '\.')[0]
-WriteLog "Latest Major version: $LatestMajorVer"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[1])
-$LatestVersion = ($LatestVersion -split '<a.*?>|</a>')[1]
-
-$InstalledVersion = RemoveTrailingZeros "$LatestVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-sdk'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
 
 # We will use the winget image from Turbo.net to download and install this app
 WriteLog "Pulling microsoft/winget from Turbo.net"

--- a/microsoft_dotnet-sdk/BuildTurboImage.ps1
+++ b/microsoft_dotnet-sdk/BuildTurboImage.ps1
@@ -52,30 +52,15 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-# Get the latest .NET major version:
-$URL = "https://versionsof.net/core/"
-$Page = Invoke-WebRequest $URL -UseBasicParsing
-
-$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
-
-ForEach ($MajorVersion in $MajorVersions) {
- # Find the first link that doesn't have "preview"
-    if ($MajorVersion -notmatch '(?i)preview') {
-        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
-        Break
-    }
-}
-
-WriteLog "Latest Stable Version: $LatestStableVersion"
-$LatestMajorVer = ($LatestStableVersion -split '\.')[0]
-WriteLog "Latest Major version: $LatestMajorVer"
-
-$URL = "https://versionsof.net/core/$LatestStableVersion"
-$Page1 = Invoke-WebRequest $URL -UseBasicParsing
-$LatestVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[1])
-$LatestVersion = ($LatestVersion -split '<a.*?>|</a>')[1]
-
-$InstalledVersion = RemoveTrailingZeros "$LatestVersion"
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-sdk'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
 
 # We will use the winget image from Turbo.net to download and install this app
 WriteLog "Pulling microsoft/winget from Turbo.net"

--- a/python_python/BuildTurboImage.ps1
+++ b/python_python/BuildTurboImage.ps1
@@ -86,7 +86,7 @@ CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on i
 ################################
 WriteLog "Performing post-install customizations."
 
-$InstalledVersion = $InstallerName.Split("-")[1]
+$InstalledVersion = ([System.IO.Path]::GetFileNameWithoutExtension($InstallerName)).Split("-")[1]
 $InstalledVersion = RemoveTrailingZeros $InstalledVersion
 
 #########################

--- a/python_python/VersionCheck.ps1
+++ b/python_python/VersionCheck.ps1
@@ -23,9 +23,7 @@ $DownloadLink = ($Page.Links | Where-Object {$_.outerHTML -like "*Windows instal
 
 $InstallerName = $DownloadLink.Split("/")[-1]
 
-$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
-
-$LatestWebVersion = $InstallerName.Split("-")[1]
+$LatestWebVersion = ([System.IO.Path]::GetFileNameWithoutExtension($InstallerName)).Split("-")[1]
 $LatestWebVersion = RemoveTrailingZeros $LatestWebVersion
 
 WriteLog "WebVersion=$LatestWebVersion"

--- a/usace_hec-hms/BuildTurboImage.ps1
+++ b/usace_hec-hms/BuildTurboImage.ps1
@@ -52,18 +52,20 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-$Page = curl 'https://www.hec.usace.army.mil/software/hec-hms/downloads.aspx' -UseBasicParsing
+$releases = Invoke-RestMethod "https://api.github.com/repos/HydrologicEngineeringCenter/hec-downloads/releases?per_page=20"
+$asset = $releases | ForEach-Object { $_.assets } | Where-Object { $_.name -like "HEC-HMS_*_Setup.exe" } | Select-Object -First 1
 
-# Get installer link for latest version
-$DownloadLink = ($Page.Links | Where-Object {$_.href -like "*.exe"})[0].href
+if (-not $asset) {
+    WriteLog "ERROR: Could not find HEC-HMS setup asset in recent GitHub releases."
+    exit 1
+}
 
-# Name of the downloaded installer file
-$InstallerName = $DownloadLink.Split("/")[-1]
-
+$DownloadLink = $asset.browser_download_url
+$InstallerName = $asset.name
 $Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 
-$InstalledVersion = Get-VersionFromExe $Installer
-$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+$asset.name -match 'HEC-HMS_(\d)(\d+)_Setup\.exe' | Out-Null
+$InstalledVersion = RemoveTrailingZeros "$($Matches[1]).$($Matches[2])"
 
 #########################
 ## Start Turbo Capture ##

--- a/usace_hec-hms/VersionCheck.ps1
+++ b/usace_hec-hms/VersionCheck.ps1
@@ -10,18 +10,14 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-$Page = curl 'https://www.hec.usace.army.mil/software/hec-hms/downloads.aspx' -UseBasicParsing
+$releases = Invoke-RestMethod "https://api.github.com/repos/HydrologicEngineeringCenter/hec-downloads/releases?per_page=20"
+$asset = $releases | ForEach-Object { $_.assets } | Where-Object { $_.name -like "HEC-HMS_*_Setup.exe" } | Select-Object -First 1
 
-# Get installer link for latest version
-$DownloadLink = ($Page.Links | Where-Object {$_.href -like "*.exe"})[0].href
-
-# Name of the downloaded installer file
-$InstallerName = $DownloadLink.Split("/")[-1]
-
-$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
-
-$LatestWebVersion = Get-VersionFromExe $Installer
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+if ($asset.name -notmatch 'HEC-HMS_(\d)(\d+)_Setup\.exe') {
+    WriteLog "ERROR: Could not find HEC-HMS setup asset in recent GitHub releases."
+    exit 1
+}
+$LatestWebVersion = RemoveTrailingZeros "$($Matches[1]).$($Matches[2])"
 
 WriteLog "WebVersion=$LatestWebVersion"
 

--- a/usace_hec-ras/BuildTurboImage.ps1
+++ b/usace_hec-ras/BuildTurboImage.ps1
@@ -52,14 +52,18 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest installer."
 
-$Page = curl 'https://www.hec.usace.army.mil/software/hec-ras/download.aspx' -UseBasicParsing
+$releases = Invoke-RestMethod "https://api.github.com/repos/HydrologicEngineeringCenter/hec-downloads/releases?per_page=20"
+$asset = $releases | ForEach-Object { $_.assets } |
+    Where-Object { $_.name -like "HEC-RAS_*_Setup.exe" -and $_.name -notlike "*with_Linux*" } |
+    Select-Object -First 1
 
-# Get installer link for latest version
-$DownloadLink = ($Page.Links | Where-Object {$_.href -like "*.exe"})[0].href
+if (-not $asset) {
+    WriteLog "ERROR: Could not find HEC-RAS setup asset in recent GitHub releases."
+    exit 1
+}
 
-# Name of the downloaded installer file
-$InstallerName = $DownloadLink.Split("/")[-1]
-
+$DownloadLink = $asset.browser_download_url
+$InstallerName = $asset.name
 $Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 
 $InstalledVersion = Get-VersionFromExe $Installer

--- a/usace_hec-ras/VersionCheck.ps1
+++ b/usace_hec-ras/VersionCheck.ps1
@@ -10,14 +10,18 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-$Page = curl 'https://www.hec.usace.army.mil/software/hec-ras/download.aspx' -UseBasicParsing
+$releases = Invoke-RestMethod "https://api.github.com/repos/HydrologicEngineeringCenter/hec-downloads/releases?per_page=20"
+$asset = $releases | ForEach-Object { $_.assets } |
+    Where-Object { $_.name -like "HEC-RAS_*_Setup.exe" -and $_.name -notlike "*with_Linux*" } |
+    Select-Object -First 1
 
-# Get installer link for latest version
-$DownloadLink = ($Page.Links | Where-Object {$_.href -like "*.exe"})[0].href
+if (-not $asset) {
+    WriteLog "ERROR: Could not find HEC-RAS setup asset in recent GitHub releases."
+    exit 1
+}
 
-# Name of the downloaded installer file
-$InstallerName = $DownloadLink.Split("/")[-1]
-
+$DownloadLink = $asset.browser_download_url
+$InstallerName = $asset.name
 $Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 
 $LatestWebVersion = Get-VersionFromExe $Installer

--- a/winscp_winscp/BuildTurboImage.ps1
+++ b/winscp_winscp/BuildTurboImage.ps1
@@ -52,31 +52,14 @@ CheckHubVersion
 ##########################################
 WriteLog "Downloading the latest MSI installer."
 
-# Use the headless-extractor to get the download link
-$url = "https://winscp.net/eng/downloads.php"
-$outputdir = "$DownloadPath\links"
-turbo config --domain=turbo.net
-turbo pull turbo/headless-extractor
-turbo run turbo/headless-extractor --using=google/chrome-x64 --isolate=merge-user --startup-file=powershell -- C:\extractor\Extract.ps1 -OutputDir $outputdir -Url $url -DOM -ExtractLinks
-
-# Define the path to the HTML file
-$DOMFilePath = "$outputdir\dom.html"
-$HtmlContent = Get-Content -Path $DOMFilePath -Raw
-
-# Split the content into lines
-$lines = $HtmlContent -split "`n"
-
-# Define a regular expression pattern
-$pattern = 'WinSCP-[\d\.]+\.msi'
-
-# Filter and output lines containing matching links
-foreach ($line in $lines) {
-    if ($line -match $pattern) {
-        $InstallerName = $matches[0]  # Use the first link that matches
-        break
-    }
+$response = Invoke-WebRequest -Uri "https://winscp.net/eng/downloads.php" -UseBasicParsing
+if ($response.Content -match 'WinSCP-([\d.]+)\.msi') {
+    $InstallerName = "WinSCP-$($Matches[1]).msi"
+} else {
+    WriteLog "ERROR: Could not find WinSCP MSI installer on downloads page."
+    exit 1
 }
-$DownloadLink =  "https://winscp.net/download/$InstallerName/download"
+$DownloadLink = "https://winscp.net/download/$InstallerName/download"
 
 pushd $DownloadPath
 $Installer = . C:\Windows\System32\curl.exe -L -o $InstallerName $DownloadLink

--- a/winscp_winscp/VersionCheck.ps1
+++ b/winscp_winscp/VersionCheck.ps1
@@ -10,34 +10,13 @@ $HubVersion = GetCurrentHubVersion $HubOrg
 ## Get latest version from the vendor site ##
 #############################################
 
-# Use the headless-extractor to get the download link
-$url = "https://winscp.net/eng/downloads.php"
-$outputdir = "$DownloadPath\links"
-turbo config --domain=turbo.net
-turbo pull turbo/headless-extractor
-turbo run turbo/headless-extractor --using=google/chrome-x64 --isolate=merge-user --startup-file=powershell -- C:\extractor\Extract.ps1 -OutputDir $outputdir -Url $url -DOM -ExtractLinks
-
-# Define the path to the HTML file
-$DOMFilePath = "$outputdir\dom.html"
-$HtmlContent = Get-Content -Path $DOMFilePath -Raw
-
-# Split the content into lines
-$lines = $HtmlContent -split "`n"
-
-# Define a regular expression pattern
-$pattern = 'WinSCP-[\d\.]+\.msi'
-
-# Filter and output lines containing matching links
-foreach ($line in $lines) {
-    if ($line -match $pattern) {
-        $InstallerName = $matches[0]  # Use the first link that matches
-        break
-    }
+$response = Invoke-WebRequest -Uri "https://winscp.net/eng/downloads.php" -UseBasicParsing
+if ($response.Content -match 'WinSCP-([\d.]+)\.msi') {
+    $LatestWebVersion = RemoveTrailingZeros $Matches[1]
+} else {
+    WriteLog "ERROR: Could not find WinSCP version on downloads page."
+    exit 1
 }
-
-# Get version number.
-$LatestWebVersion = ($InstallerName -replace "winscp-") -replace ".msi"
-$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
 
 WriteLog "WebVersion=$LatestWebVersion"
 


### PR DESCRIPTION
## Changes

### 7-Zip
Switched from scraping 7-zip.org to the GitHub API (`ip7z/7zip`). Version check no longer requires downloading the MSI.

### Git
Switched from scraping git-scm.com to the GitHub API (`git-for-windows/git`). Version is now parsed directly from the asset filename.

### Google Chrome / Chrome x64
Replaced MSI download + Shell COM object inspection with a single call to the Chromium Dash API.

### Google Earth Pro
Removed download page scraping; now uses a stable direct download URL. Version is read from the registry post-install. Version check is skipped since the version can't be determined without installing.

### DYMO Connect
Replaced headless browser extraction with a GitHub API call to `microsoft/winget-pkgs` manifest directory to resolve the latest version, then constructs the download URL directly.

### WinSCP
Replaced headless browser + DOM parsing with a simple regex match against the WinSCP downloads page HTML.

### Microsoft .NET (runtime, desktop runtime, ASP.NET runtime, SDK — x86 and x64)
Replaced multi-step versionsof.net scraping with the official .NET release metadata API (`dotnetcli.blob.core.windows.net`). SDK variants use `latest-sdk`; runtime variants use `latest-release`.

### HEC-HMS / HEC-RAS
Switched from scraping USACE download pages to the GitHub API (`HydrologicEngineeringCenter/hec-downloads`). HEC-HMS version is parsed from the asset filename pattern.

### Python
Fixed filename parsing to use `Path.GetFileNameWithoutExtension()` before splitting, preventing incorrect version extraction when the filename includes an extension.

### GlobalBuildScript
- Fixed version sorting to handle single-component version strings (e.g. `"24"`) that would previously throw a cast exception when compared as `[System.Version]`
- Fixed `HubOrg` parsing to split on both `_` and `/` delimiters so repo owner/name is correctly extracted in either format
- Fixed off-by-one errors in `RemoveTrailingZeros` array slicing that could cause incorrect version strings