### PR TITLE
Log TurboStudioVersion, DownloadUrl, and DownloadHash in GlobalBuildScript

### DIFF
--- a/!include/GlobalBuildScript.ps1
+++ b/!include/GlobalBuildScript.ps1
@@ -11,6 +11,13 @@ $NewLine = "`r`n"  #  Adds a blank line to the Log file
 $DownloadPath = New-Item -Path $packagePath -Name "Installer" -ItemType "directory" -Force # create an Installer directory in the Desktop Package folder
 
 
+# WriteLog - writes string message parameter to log file and console.
+Function WriteLog([String]$message) {
+    Write-Host "$message"
+    $timestamp = Get-Date -Format o | foreach {$_ -replace ":", "."}
+    ("$timestamp $message").replace($NewLine,"") | Out-File -FilePath $LogFile -Append # Strip new lines from message then output to log
+}
+
 #####################
 ## Turbo Variables ##
 #####################
@@ -37,7 +44,7 @@ foreach ($path in $possibleXStudioPaths) {
 if ($XStudio) {
     Write-Host "Found XStudio.exe at: $XStudio"
     $turboStudioVersion = (Get-Item $XStudio).VersionInfo.ProductVersion
-    Write-Host "TurboStudioVersion=$turboStudioVersion"
+    WriteLog "TurboStudioVersion=$turboStudioVersion"
 } else {
     Write-Error "XStudio.exe was not found in expected locations.`nChecked:`n - $($possibleXStudioPaths -join "`n - ")"
 }
@@ -81,13 +88,6 @@ $FinalXapplPath = "$TurboCaptureDir\FinalCapture.xappl"  #  XAPPL with any modif
 ###############
 ## Functions ##
 ###############
-
-# WriteLog - writes string message parameter to log file and console.
-Function WriteLog([String]$message) {
-    Write-Host "$message"
-    $timestamp = Get-Date -Format o | foreach {$_ -replace ":", "."}
-    ("$timestamp $message").replace($NewLine,"") | Out-File -FilePath $LogFile -Append # Strip new lines from message then output to log
-}
 
 # Get current Hub revisions of application
 Function GetHubRevisions($HubOrg,$URL) {

--- a/!include/GlobalBuildScript.ps1
+++ b/!include/GlobalBuildScript.ps1
@@ -327,6 +327,7 @@ Function Get-VersionFromExe {
 }
 
 Function GetVersionFromRegistry($AppPartName) {
+ $RegistryVersion = $null
  # Get the installed version from the 64 bit registry
  $key = [Microsoft.Win32.RegistryKey]::OpenBaseKey([Microsoft.Win32.RegistryHive]::LocalMachine, [Microsoft.Win32.RegistryView]::Registry64)
  $subKey = $key.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall")

--- a/!include/GlobalBuildScript.ps1
+++ b/!include/GlobalBuildScript.ps1
@@ -327,7 +327,6 @@ Function Get-VersionFromExe {
 }
 
 Function GetVersionFromRegistry($AppPartName) {
- $RegistryVersion = $null
  # Get the installed version from the 64 bit registry
  $key = [Microsoft.Win32.RegistryKey]::OpenBaseKey([Microsoft.Win32.RegistryHive]::LocalMachine, [Microsoft.Win32.RegistryView]::Registry64)
  $subKey = $key.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall")
@@ -343,9 +342,9 @@ Function GetVersionFromRegistry($AppPartName) {
 
  if ([string]::IsNullOrWhiteSpace($RegistryVersion)) { # Check the 32bit reg keys if no version found
       foreach ($subkey in Get-ChildItem ("HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall")) {
-        $name = Get-ItemPropertyValue $subkey.PSPath -Name DisplayName -ErrorAction SilentlyContinue
+        $name = (Get-ItemProperty $subkey.PSPath).DisplayName
         if ($name -match "$AppPartName") {
-            $RegistryVersion = Get-ItemPropertyValue $subkey.PSPath -Name DisplayVersion -ErrorAction SilentlyContinue
+            $RegistryVersion = (Get-ItemProperty $subkey.PSPath).DisplayVersion
         }
       }
  }

--- a/!include/GlobalBuildScript.ps1
+++ b/!include/GlobalBuildScript.ps1
@@ -343,9 +343,9 @@ Function GetVersionFromRegistry($AppPartName) {
 
  if ([string]::IsNullOrWhiteSpace($RegistryVersion)) { # Check the 32bit reg keys if no version found
       foreach ($subkey in Get-ChildItem ("HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall")) {
-        $name = (Get-ItemProperty $subkey.PSPath).DisplayName
+        $name = Get-ItemPropertyValue $subkey.PSPath -Name DisplayName -ErrorAction SilentlyContinue
         if ($name -match "$AppPartName") {
-            $RegistryVersion = (Get-ItemProperty $subkey.PSPath).DisplayVersion
+            $RegistryVersion = Get-ItemPropertyValue $subkey.PSPath -Name DisplayVersion -ErrorAction SilentlyContinue
         }
       }
  }

--- a/!include/GlobalBuildScript.ps1
+++ b/!include/GlobalBuildScript.ps1
@@ -36,6 +36,8 @@ foreach ($path in $possibleXStudioPaths) {
 
 if ($XStudio) {
     Write-Host "Found XStudio.exe at: $XStudio"
+    $turboStudioVersion = (Get-Item $XStudio).VersionInfo.ProductVersion
+    Write-Host "TurboStudioVersion=$turboStudioVersion"
 } else {
     Write-Error "XStudio.exe was not found in expected locations.`nChecked:`n - $($possibleXStudioPaths -join "`n - ")"
 }
@@ -166,8 +168,11 @@ Function DownloadInstaller($DownloadLink,$DownloadPath, $InstallerName) {
         WriteLog "File already downloaded: $DownloadPath\$InstallerName"
     } else {
         WriteLog "Downloading latest installer to $DownloadPath\$InstallerName"
+        WriteLog "DownloadUrl=$DownloadLink"
         wget $DownloadLink -O $DownloadPath\$InstallerName
         Wait-ForFileExistence $DownloadPath\$InstallerName -Iterations 3600 -SleepTime 1  # Exit if file doesn't exist after 60 minutes
+        $hash = (Get-FileHash "$DownloadPath\$InstallerName" -Algorithm SHA256).Hash
+        WriteLog "DownloadHash=sha256:$($hash.ToLower())"
     }
     Return "$DownloadPath\$InstallerName"
 }


### PR DESCRIPTION
## Summary

- Moves `WriteLog` function definition above the Turbo Variables block so it is
  available during XStudio resolution
- Logs `TurboStudioVersion` (from XStudio.exe's `ProductVersion`) immediately
  after XStudio is found
- Logs `DownloadUrl` before each installer download in `DownloadInstaller`
- Logs `DownloadHash` (SHA-256) of each downloaded installer after the file is
  confirmed to exist

All apps automatically get these log lines since every `BuildTurboImage.ps1`
dot-sources `GlobalBuildScript.ps1`.

## Test plan

- [ x ] Verify `TurboStudioVersion=` appears in build log after the XStudio path line
- [ x ] Verify `DownloadUrl=` appears in build log before the wget download
- [ x ] Verify `DownloadHash=sha256:...` appears in build log after the installer is downloaded
- [ x ] Confirm all three values are written to the log file (not just console)
