### PR TITLE
Add arm64 Python capture, and fix first-build Hub version check

### DIFF
--- a/!include/GlobalBuildScript.ps1
+++ b/!include/GlobalBuildScript.ps1
@@ -111,14 +111,46 @@ Function GetHubRevisions($HubOrg,$URL) {
     $headers.Add("X-Turbo-Api-Version", "1")
 
     # Get the revisions array for the repo
+    # A 404 here means the repo has never been published: a brand-new app or variant
+    # whose first build has to create it. That is the bootstrap case, not an error, so
+    # return $null and let the caller decide. Only this call is guarded -- a 404 from
+    # the login endpoint above is a bad hub URL and must still fail loudly. Any other
+    # status (401, 5xx, network) is rethrown so real outages are never mistaken for a
+    # new repo.
     $reqUrl = $URL + '/io/_hub/repo/' + $repoOwner + '/' + $repoName + '/revisions?withTags'
-    $response = Invoke-RestMethod -Uri $reqUrl -Method Get -Headers $headers
+    try {
+        $response = Invoke-RestMethod -Uri $reqUrl -Method Get -Headers $headers
+    } catch {
+        $statusCode = $null
+        if ($_.Exception.Response) {
+            # Windows PowerShell 5.1 exposes HttpStatusCode (value__ for the int);
+            # PowerShell 7 exposes HttpResponseMessage. Both cast cleanly to int.
+            $statusCode = [int]$_.Exception.Response.StatusCode
+        }
+        if ($statusCode -eq 404) {
+            WriteLog "Repo $HubOrg does not exist on $URL. Treating as a first build."
+            Return $null
+        }
+        throw
+    }
     Return $response
 }
 
 # Get Current Hub Version of application
 Function GetCurrentHubVersion($HubOrg,$URL) {
     $response = GetHubRevisions $HubOrg $URL
+
+    # Repo not on the hub yet (first build): report 0.0 rather than an empty string.
+    # Compare-Versions treats null/""/".0" as "failed to read the hub" and aborts the
+    # build, which is right for a lookup failure but wrong here -- nothing is published,
+    # so any real web version is newer and the build should proceed. 0.0 casts to
+    # [Version] and loses that comparison to every real version, so the existing
+    # comparison logic handles this case unchanged.
+    if ($null -eq $response) {
+        WriteLog "HubVersion=0.0 (nothing published for $HubOrg yet)"
+        Return '0.0'
+    }
+
     $VersionList = $response.tags | Sort-Object {
         $parts = ($_ -split '\.').Count
         if ($parts -eq 1) { [System.Version]("$_" + ".0") } else { [System.Version]$_ }
@@ -133,6 +165,12 @@ Function GetCurrentHubVersion($HubOrg,$URL) {
 # Get the current Hub hash of the application
 Function GetCurrentHubHash($HubOrg,$URL) {
     $response = GetHubRevisions $HubOrg $URL
+
+    # No repo on the hub means no image and so no hash. Return $null explicitly rather
+    # than indexing into a null response.
+    if ($null -eq $response) {
+        Return $null
+    }
 
     # Get the first imageID from the repo (this is the hash)
     if ($response.imageid.count -gt 1) {

--- a/python_python-arm64/BuildTurboImage.ps1
+++ b/python_python-arm64/BuildTurboImage.ps1
@@ -1,0 +1,115 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Python Software Foundation"
+$AppDesc = "Programming language that lets you work quickly and integrate systems more effectively."
+$AppName = "Python"
+$VendorURL = "www.python.org"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$URL = 'https://www.python.org/downloads/windows/'
+$Page = curl $URL -UseBasicParsing
+
+# Get installer link for latest version
+$LatestInstaller = ($Page.Links | Where-Object {$_.href -like "*downloads/release/python*"})[0].href
+
+$URL = 'https://www.python.org' + $LatestInstaller
+
+$Page = curl $URL -UseBasicParsing
+$DownloadLink = ($Page.Links | Where-Object {$_.outerHTML -like "*Windows installer*ARM64*"})[0].href
+
+$InstallerName = $DownloadLink.Split("/")[-1]
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess "$DownloadPath\$InstallerName" "/quiet InstallAllUsers=1 PrependPath=1" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+$InstalledVersion = $InstallerName.Split("-")[1]
+$InstalledVersion = RemoveTrailingZeros $InstalledVersion
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/python_python-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/python_python-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,13 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+######################
+# Edit Startup Files #
+######################
+## Change the container startup file to python.exe
+$StartupFiles = $xappl.Configuration.SelectSingleNode("StartupFiles")
+$StartupFiles.SelectSingleNode("StartupFile[@tag='pythonw']").default = 'False'
+$parentNode = $StartupFiles.SelectNodes("StartupFile[@tag='python']")
+ForEach ($childNodes in $parentNode) {
+    $childNodes.SetAttribute("default", "True")
+}

--- a/python_python-arm64/VersionCheck.ps1
+++ b/python_python-arm64/VersionCheck.ps1
@@ -1,0 +1,40 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$URL = 'https://www.python.org/downloads/windows/'
+$Page = curl $URL -UseBasicParsing
+
+# Get installer link for latest version
+$LatestInstaller = ($Page.Links | Where-Object {$_.href -like "*downloads/release/python*"})[0].href
+
+$URL = 'https://www.python.org' + $LatestInstaller
+
+$Page = curl $URL -UseBasicParsing
+$DownloadLink = ($Page.Links | Where-Object {$_.outerHTML -like "*Windows installer*ARM64*"})[0].href
+
+$InstallerName = $DownloadLink.Split("/")[-1]
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = $InstallerName.Split("-")[1]
+$LatestWebVersion = RemoveTrailingZeros $LatestWebVersion
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}


### PR DESCRIPTION
Adds an ARM64 variant of the Python capture, plus the shared-script fix needed to make any brand-new app or variant build at all.

## `python_python-arm64`

Copied from `python_python-x64` (the bare `python_python` is the 32-bit one) with the installer download repointed at the ARM64 build. Exactly two lines differ from the x64 source:

```diff
- "*Windows installer*64*"    -> python-<ver>-amd64.exe
+ "*Windows installer*ARM64*" -> python-<ver>-arm64.exe
```

The filter lives in **both** `BuildTurboImage.ps1` and `VersionCheck.ps1`; changing only the former would have left the version check polling the amd64 artifact. Capture recipe, install switches, `PostCaptureModifications.ps1` and version parsing are untouched. `HubOrg` derives from the directory name, so it becomes `python/python-arm64` automatically.

No `.applab.yml`. Architecture comes from the `-arm64` directory suffix via `Get-AppArch`, which forces `win11-arm` / token `win11-arm64` and routes the job to the ARM pool on macmini1, independent of the existing x64 capture. Discovery confirms:

```
python_python          arch=x64    os=win10      runs_on=[app-capture, win10-x64]
python_python-x64      arch=x64    os=win10      runs_on=[app-capture, win10-x64]
python_python-arm64    arch=arm64  os=win11-arm  runs_on=[app-capture, win11-arm64]
```

## Hub version check on a first build

The first arm64 run failed before downloading anything. `GetHubRevisions` called `Invoke-RestMethod` on the repo revisions endpoint with no error handling, and the repo does not exist on the Hub until something is pushed to it — so the 404 killed the build. Chicken-and-egg: the build must succeed once to create the repo, but the version check refused to run until the repo existed. This affects **any** new app or variant, not just arm64; the previous workaround was a `VersionCheck.ps1` that skipped the comparison entirely (see `klayout_*`).

Only the revisions call is guarded, and only on 404 — it returns `$null`, which `GetCurrentHubVersion` maps to `'0.0'`. That casts to `[Version]` and loses to every real version, so the build proceeds and `Compare-Versions` is left untouched, which matters because 158 app directories call it.

Deliberately still fatal:

- 404 from the **login** call — that's a bad Hub URL, not a missing repo
- 401 / 403 / 5xx / network errors — a real Hub outage must never be mistaken for a new repo and silently republished
- an empty Hub version reaching `Compare-Versions` — still aborts with `BuildResult=failed`

`GetCurrentHubHash` gets the same null guard rather than indexing into a null response.

### Blast radius

Every app loads `!include/GlobalBuildScript.ps1`, so all 158 are in scope. The behavioural change is confined to the "revisions returns 404" path, reachable today only by an app that has never been published — existing apps take byte-identical paths. Revertible on its own; it does not depend on the arm64 commit.

**Reviewer call:** a 404 now means "build it" rather than "stop", so a typo'd directory name will build and push a new Hub repo under the wrong name instead of failing loudly. It's logged but not blocked. The stricter alternative is an opt-in marker (e.g. `first_build: true` in `.applab.yml`) at the cost of more ceremony per new app.

## Testing

There are no Pester tests over `GlobalBuildScript.ps1`, so the change was exercised with a harness against a side-effect-free copy (the real script creates Desktop folders at load time). 12/12 pass: existing repos still resolve their newest tag; 404 yields the `0.0` sentinel; 401/403/500/503, a login 404 and a response-less network error all still throw; an empty Hub version still aborts.

End-to-end capture: https://github.com/codesystems/applab/actions/runs/30130917510 — success, routed to `win11-arm`.

Resulting image runs natively:

```
turbo pull python/python-arm64
Pulling image python-arm64:3.14.6 from https://applab.turboqa.net/users/python

Python 3.14.6 (tags/v3.14.6:c63aec6, Jun 10 2026, 11:16:52) [MSC v.1944 64 bit (ARM64)] on win32
```

`64 bit (ARM64)` is the check that matters — the amd64 installer would have captured and run fine under emulation and reported `64 bit (AMD64)`, so this confirms the ARM64 artifact was genuinely picked up. The successful push also created the `python/python-arm64` Hub repo, so this app takes the normal version-check path from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
