### PR TITLE
Add arm64 variants for 12 apps

### DIFF
--- a/7-zip_7-zip-arm64/BuildTurboImage.ps1
+++ b/7-zip_7-zip-arm64/BuildTurboImage.ps1
@@ -1,0 +1,122 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "7-Zip"
+$AppDesc = "Open source file archiver and compression tool."
+$AppName = "7-Zip ARM64"
+$VendorURL = "https://7-zip.org/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+$release = Invoke-RestMethod "https://api.github.com/repos/ip7z/7zip/releases/latest"
+# 7-Zip does not publish an ARM64 MSI -- only the exe installer (e.g. 7z2602-arm64.exe).
+# The name filter excludes the linux tarballs (7z*-linux-arm64.tar.xz) by requiring .exe.
+$asset = $release.assets | Where-Object { $_.name -like "*-arm64.exe" }
+$DownloadLink = $asset.browser_download_url
+$InstallerName = $asset.name
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# exe installer (no ARM64 MSI exists); /S is the 7-Zip installer's silent switch
+$ProcessExitCode = RunProcess $Installer "/S" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Associate file types with 7zFM.exe
+  &cmd.exe /C assoc .7z=7-Zip.7z
+  &cmd.exe /C --% ftype 7-Zip.7z="C:\Program Files\7-Zip\7zFM.exe" "%1"
+  &cmd.exe /C assoc .zip=7-Zip.zip
+  &cmd.exe /C --% ftype 7-Zip.zip="C:\Program Files\7-Zip\7zFM.exe" "%1"
+  &cmd.exe /C assoc .bz2=7-Zip.bz2
+  &cmd.exe /C --% ftype 7-Zip.bz2="C:\Program Files\7-Zip\7zFM.exe" "%1"
+  &cmd.exe /C assoc .gz=7-Zip.gz
+  &cmd.exe /C --% ftype 7-Zip.gz="C:\Program Files\7-Zip\7zFM.exe" "%1"
+  &cmd.exe /C assoc .tar=7-Zip.tar
+  &cmd.exe /C --% ftype 7-Zip.tar="C:\Program Files\7-Zip\7zFM.exe" "%1"
+  &cmd.exe /C assoc .tgz=7-Zip.tgz
+  &cmd.exe /C --% ftype 7-Zip.tgz="C:\Program Files\7-Zip\7zFM.exe" "%1"
+  
+$InstalledVersion = GetVersionFromRegistry "7-zip"
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion

--- a/7-zip_7-zip-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/7-zip_7-zip-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,2 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions

--- a/7-zip_7-zip-arm64/VersionCheck.ps1
+++ b/7-zip_7-zip-arm64/VersionCheck.ps1
@@ -1,0 +1,25 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$release = Invoke-RestMethod "https://api.github.com/repos/ip7z/7zip/releases/latest"
+$LatestWebVersion = RemoveTrailingZeros $release.tag_name
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/eclipse_temurin-lts-arm64/BuildTurboImage.ps1
+++ b/eclipse_temurin-lts-arm64/BuildTurboImage.ps1
@@ -1,0 +1,151 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Eclipse Adoptium"
+$AppDesc = "Eclipse Temurin is the open source Java SE build based upon OpenJDK"
+$AppName = "Temurin JDK LTS"
+$VendorURL = "https://adoptium.net/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+# Get major version of the latest release
+$url = "https://api.adoptium.net/v3/info/available_releases"
+$response = curl -Uri $url -UseBasicParsing
+$jsonData = $response.Content | ConvertFrom-Json
+
+# Adoptium does not ship windows/aarch64 binaries for every LTS major (as of 2026-07 only
+# JDK 21 has them; 25 does not yet). Walk the LTS list newest-first and take the first
+# major that actually has an aarch64 Windows release, so this picks 25 automatically the
+# day those binaries appear.
+$Platform = 'windows'
+$Type = 'jdk'
+$Arch = 'aarch64'
+$ReleaseInfo = $null
+foreach ($candidateMajor in ($jsonData.available_lts_releases | Sort-Object -Descending)) {
+    $Assets = Invoke-WebRequest -Uri "https://api.adoptium.net/v3/assets/latest/$candidateMajor/hotspot?architecture=$Arch&image_type=$Type&os=$Platform&vendor=eclipse" -UseBasicParsing | ConvertFrom-Json
+    if ($Assets) {
+        $latestMajorVersion = $candidateMajor
+        $ReleaseInfo = $Assets
+        break
+    }
+    WriteLog "No windows/$Arch Temurin binaries for JDK $candidateMajor, trying next-oldest LTS."
+}
+if (-not $ReleaseInfo) {
+    WriteLog "No LTS major has windows/$Arch Temurin binaries. Exiting."
+    WriteLog "BuildResult=failed"
+    Exit 0
+}
+
+# Download the zip
+$InstallerName = $ReleaseInfo.binary.package.name
+$DownloadLink = "https://api.adoptium.net/v3/binary/latest/$latestMajorVersion/ga/$Platform/$Arch/$Type/hotspot/normal/eclipse"
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+# Get the version from the Release json
+$majorVer = $ReleaseInfo.version.major
+$minorVer = $ReleaseInfo.version.minor
+$buildVer = $ReleaseInfo.version.build
+$InstalledVersion = "$majorVer.$minorVer.$buildVer"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+New-Item -Path "c:\Program Files" -Name "Eclipse Adoptium" -ItemType Directory
+# Extract the zip file for the install
+Expand-Archive -Path $DownloadPath\$InstallerName -DestinationPath "C:\Program Files\Eclipse Adoptium"
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Register .jar files with javaw.exe
+$InstallDir = Get-ChildItem -Path "c:\Program Files\Eclipse Adoptium" -Directory | Where-Object { $_.Name -like 'jdk*' }
+
+$regKey = "HKLM:\SOFTWARE\Classes\.jar"
+if (-not (Test-Path $regKey)) {New-Item -Path $regKey -Force | Out-Null}
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\.jar" -Name '(Default)' -Value "Eclipse Adoptium.jarfile"
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\.jar" -Name 'Content Type' -Value "application/java-archive"
+
+$regKey = "HKLM:\SOFTWARE\Classes\Eclipse Adoptium.jarfile\shell\open\command"
+if (-not (Test-Path $regKey)) {New-Item -Path $regKey -Force | Out-Null}
+Set-ItemProperty -Path $regKey -Name '(Default)' -Value "`"C:\Program Files\Eclipse Adoptium\$($InstallDir)\bin\javaw.exe`" -jar `"%1`" %*"
+
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/eclipse_temurin-lts-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/eclipse_temurin-lts-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,15 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+####################
+# Environment Vars #
+####################
+
+# Get the folder the JDK was extracted to
+$InstallDir = Get-ChildItem -Path "c:\Program Files\Eclipse Adoptium" -Directory | Where-Object { $_.Name -like 'jdk*' }
+
+$EnvironmentVariablesEx = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("EnvironmentVariablesEx")
+# Add the jdk bin directory to the PATH env var
+AddEnvVar "PATH" "Inherit" "Prepend" ";" "@PROGRAMFILES@\Eclipse Adoptium\$InstallDir\bin"
+# Add the JAVA_HOME env var
+AddEnvVar "JAVA_HOME" "Inherit" "Replace" "" "@PROGRAMFILES@\Eclipse Adoptium\$InstallDir"

--- a/eclipse_temurin-lts-arm64/VersionCheck.ps1
+++ b/eclipse_temurin-lts-arm64/VersionCheck.ps1
@@ -1,0 +1,52 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Get major version of the latest release
+$url = "https://api.adoptium.net/v3/info/available_releases"
+$response = curl -Uri $url -UseBasicParsing
+$jsonData = $response.Content | ConvertFrom-Json
+
+# Same selection as BuildTurboImage.ps1: newest LTS major that has windows/aarch64
+# binaries (not every LTS gets them -- see comment there).
+$Platform = 'windows'
+$Type = 'jdk'
+$Arch = 'aarch64'
+$ReleaseInfo = $null
+foreach ($candidateMajor in ($jsonData.available_lts_releases | Sort-Object -Descending)) {
+    $Assets = Invoke-WebRequest -Uri "https://api.adoptium.net/v3/assets/latest/$candidateMajor/hotspot?architecture=$Arch&image_type=$Type&os=$Platform&vendor=eclipse" -UseBasicParsing | ConvertFrom-Json
+    if ($Assets) {
+        $ReleaseInfo = $Assets
+        break
+    }
+}
+if (-not $ReleaseInfo) {
+    WriteLog "No LTS major has windows/$Arch Temurin binaries. Exiting."
+    WriteLog "BuildResult=failed"
+    Exit 0
+}
+
+# Get the version from the Release json
+$majorVer = $ReleaseInfo.version.major
+$minorVer = $ReleaseInfo.version.minor
+$buildVer = $ReleaseInfo.version.build
+$LatestWebVersion = "$majorVer.$minorVer.$buildVer"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/git_git-arm64/BuildTurboImage.ps1
+++ b/git_git-arm64/BuildTurboImage.ps1
@@ -1,0 +1,105 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Git"
+$AppDesc = "A fast, scalable, distributed revision control system."
+$AppName = "Git"
+$VendorURL = "http://git-scm.com/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$release = Invoke-RestMethod "https://api.github.com/repos/git-for-windows/git/releases/latest"
+$asset = $release.assets | Where-Object { $_.name -like "Git-*-arm64.exe" } | Select-Object -First 1
+$DownloadLink = $asset.browser_download_url
+$InstallerName = $asset.name
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$InstalledVersion = RemoveTrailingZeros ($InstallerName -split '-')[1]
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess $Installer "/SILENT" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+  
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion

--- a/git_git-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/git_git-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,12 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+## Update startup file to git-cmd rather than git-bash.
+ $StartupFiles = $xappl.Configuration.SelectSingleNode("StartupFiles")
+ # Set default to False for all startup files to disable them on launch.
+ $StartupFiles.SelectSingleNode("StartupFile[@default='True']").default = 'False'
+ # Set default to True for the git-cmd executable
+ ($StartupFiles.SelectSingleNode("StartupFile[@node='@PROGRAMFILES@\Git\git-cmd.exe']")).SetAttribute("default","True")
+
+ # Add a new startup file for headless mode "C:\Program Files\Git\cmd\git.exe"
+ AddStartupFile "@PROGRAMFILES@\Git\cmd\git.exe" "headless" "" $False "AnyCpu"

--- a/git_git-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/git_git-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -2,11 +2,24 @@ $PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\
 . $PostCaptureFunctionsPath  # Include the script that contains post capture functions
 
 ## Update startup file to git-cmd rather than git-bash.
+ ## Null-guarded: the ARM64 capture does not register the same startup-file set as x64
+ ## (the x64 recipe's node lookups came back empty and the bare method calls killed the
+ ## whole post-capture step). If git-cmd.exe was not captured as a startup file, add it
+ ## as the default instead of dereferencing a missing node.
  $StartupFiles = $xappl.Configuration.SelectSingleNode("StartupFiles")
+ if (-not $StartupFiles) {
+     $StartupFiles = $xappl.Configuration.AppendChild($xappl.CreateElement("StartupFiles"))
+ }
  # Set default to False for all startup files to disable them on launch.
- $StartupFiles.SelectSingleNode("StartupFile[@default='True']").default = 'False'
+ $defaultStartupFile = $StartupFiles.SelectSingleNode("StartupFile[@default='True']")
+ if ($defaultStartupFile) { $defaultStartupFile.SetAttribute("default", "False") }
  # Set default to True for the git-cmd executable
- ($StartupFiles.SelectSingleNode("StartupFile[@node='@PROGRAMFILES@\Git\git-cmd.exe']")).SetAttribute("default","True")
+ $gitCmdStartupFile = $StartupFiles.SelectSingleNode("StartupFile[@node='@PROGRAMFILES@\Git\git-cmd.exe']")
+ if ($gitCmdStartupFile) {
+     $gitCmdStartupFile.SetAttribute("default","True")
+ } else {
+     AddStartupFile "@PROGRAMFILES@\Git\git-cmd.exe" "" "" $True "AnyCpu"
+ }
 
  # Add a new startup file for headless mode "C:\Program Files\Git\cmd\git.exe"
  AddStartupFile "@PROGRAMFILES@\Git\cmd\git.exe" "headless" "" $False "AnyCpu"

--- a/git_git-arm64/VersionCheck.ps1
+++ b/git_git-arm64/VersionCheck.ps1
@@ -1,0 +1,26 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$release = Invoke-RestMethod "https://api.github.com/repos/git-for-windows/git/releases/latest"
+$asset = $release.assets | Where-Object { $_.name -like "Git-*-arm64.exe" } | Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros ($asset.name -split '-')[1]
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/google_chrome-arm64/BuildTurboImage.ps1
+++ b/google_chrome-arm64/BuildTurboImage.ps1
@@ -1,0 +1,152 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Google"
+$AppDesc = "Free web browser developed by Google, enhanced for performance and privacy."
+$AppName = "Chrome ARM64"
+$VendorURL = "https://google.com/chrome"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Get installer link for latest version
+## Simplified link is https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise_arm64.msi. However, our link disables browser usage stats and installs for all users.
+$DownloadLink = "https://dl.google.com/tag/s/appguid%3D%7B8A69D345-D564-463C-AFF1-A69D9E530F96%7D%26iid%3D%7B2CC0992A-8A31-8D75-167C-5C46238DE706%7D%26lang%3Den%26browser%3D5%26usagestats%3D0%26appname%3DGoogle%2520Chrome%26needsadmin%3Dtrue%26ap%3Darm64-stable-statsdef_0%26brand%3DGCEW/dl/chrome/install/googlechromestandaloneenterprise_arm64.msi"
+
+# Name of the downloaded installer file
+$InstallerName = "googlechromestandaloneenterprise.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess "msiexec.exe" "/I $Installer /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Copy initial_prefernces file - this file doesn't currently contain any changes to defaults but allows for future changes if required.
+Copy-Item "$SupportFiles\initial_preferences" -Destination "C:\Program Files\Google\Chrome\Application\"  -Force
+# Copy Google folder to localappdata - this folder contains files to prevent the Google Welcome page on first launch.
+Copy-Item -Path "$SupportFiles\Google" -Destination "$env:LOCALAPPDATA\" -Recurse -Force
+
+# Create "Chrome Apps" folder in Start Menu - creating this folder will prevent google app shortcuts from getting created
+Copy-Item -Path "$SupportFiles\Chrome Apps" -Destination "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\" -Recurse -Force
+
+# Kill updater.exe if running
+taskkill.exe /f /im updater.exe /t
+
+# Delete Google Update
+# Get all services matching the pattern "google*" and "gupdate*"
+$pattern = "^(google|gupdate)"
+$services = Get-Service | Where-Object { $_.Name -match $pattern }
+
+# Iterate through each service and stop it if it's running, then remove it
+foreach ($service in $services) {
+    if ($service.Status -eq "Running") {
+        sc.exe stop $service.ServiceName
+    }
+    sc.exe delete $service.ServiceName
+}
+
+# Delete Google update folders
+if (Test-Path "C:\Program Files (x86)\Google\Update") { 
+    Remove-Item -Path "C:\Program Files (x86)\Google\Update\*" -Recurse -Force
+}
+if (Test-Path "C:\Program Files (x86)\Google\GoogleUpdater") { 
+    Remove-Item -Path "C:\Program Files (x86)\Google\GoogleUpdater\*" -Recurse -Force
+}
+
+$InstalledVersion = GetVersionFromRegistry "Google Chrome"
+
+# Delete installer files
+if (Test-Path "C:\Program Files\Google\Chrome\Application\$InstalledVersion\Installer") { 
+    Remove-Item "C:\Program Files\Google\Chrome\Application\$InstalledVersion\Installer\*" -Recurse -Force 
+}
+
+# Set the policy key to prevent the default browser banner
+&reg add HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Google\Chrome /v DefaultBrowserSettingEnabled /t REG_DWORD /d 0 /f
+&reg add HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Google\Chrome /v PrivacySandboxPromptEnabled /t REG_DWORD /d 0 /f
+
+# Set the policy key to disable the chrome audio sandbox service
+&reg add HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Google\Chrome /v AudioSandboxEnabled /t REG_DWORD /d 0 /f
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/google_chrome-arm64/SupportFiles/Google/Chrome/User Data/Default/Preferences
+++ b/google_chrome-arm64/SupportFiles/Google/Chrome/User Data/Default/Preferences
@@ -1,0 +1,1 @@
+{ "browser": { "has_seen_welcome_page": true }}

--- a/google_chrome-arm64/SupportFiles/Google/Chrome/User Data/Local State
+++ b/google_chrome-arm64/SupportFiles/Google/Chrome/User Data/Local State
@@ -1,0 +1,1 @@
+{"browser":{"has_shown_refresh_2099_whats_new":true,"last_whats_new_version":999}}

--- a/google_chrome-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/google_chrome-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,115 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+
+# Configure vm settings
+$VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
+$virtualizationSettings.isolateWindowClasses = [string]$true
+
+# Set MachineSid - allows Chrome user settings to be portable between devices using the same sandbox
+$MachineSid = $xappl.Configuration.SelectSingleNode("Device").SelectSingleNode("MachineSid")
+$MachineSid.InnerText = "S-1-5-21-992951991-166803189-1664049914"
+
+# Edit ObjectMaps - Isolating this message window allows multiple Chrome instances to run side-by-side.
+$ObjectMaps = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("ObjectMaps")
+$node = $xappl.CreateElement("ObjectMap")
+$node.SetAttribute("value","window://Chrome_MessageWindow:0")
+$ObjectMaps.AppendChild($node)
+
+
+###################
+# Edit Filesystem #
+###################
+
+
+# Set the noSync attribute on the LOCALAPPDATA\Google and subfolders
+$parentNode = $Filesystem.SelectNodes("Directory[@name='@APPDATALOCAL@']/Directory[@name='Google']/descendant-or-self::*")
+ForEach ($childNodes in $parentNode) {
+    $childNodes.SetAttribute("noSync", "False")
+}
+
+# Sets Isolation on the folders
+$Filesystem.SelectSingleNode("Directory[@name='@APPDATALOCAL@']/Directory[@name='Google']").isolation = "Full"
+$Filesystem.SelectSingleNode("Directory[@name='@PROGRAMFILESX86@']/Directory[@name='Google']").isolation = "Full"
+$Filesystem.SelectSingleNode("Directory[@name='@PROGRAMFILES@']/Directory[@name='Google']").isolation = "Full"
+
+#################
+# Edit Registry #
+#################
+## NOTE: Beware of case sensitivity when making registry changes.  eg. The registry value type "String" requires an upper-case 'S'
+##       When specifying a registry value, "OpenWithProgids" is different from "OpenWithProgIds"
+
+# Create HKCU\Software
+$userSoftwareKey = $Registry.SelectSingleNode("Key[@name='@HKCU@']/Key[@name='Software']")
+if (-not $userSoftwareKey) {
+    AddRegKey "Key[@name='@HKCU@']" "Software" "WriteCopy" "False" "False"
+}
+
+# Set Full isolation on HKCU\Software\Google and subkeys
+$userGoogleKey = $Registry.SelectSingleNode("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Google']")
+if (-not $userGoogleKey) {
+    AddRegKey "Key[@name='@HKCU@']/Key[@name='Software']" "Google" "Full" "False" "False"
+}
+$parentNode = $Registry.SelectNodes("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Google']/descendant-or-self::*")
+ForEach ($childNodes in $parentNode) {
+    $childNodes.SetAttribute("isolation", "Full")
+}
+# Set Full isolation on HKLM\SOFTWARE\WOW6432Node\Google and subkeys
+$parentNode = $Registry.SelectNodes("Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='WOW6432Node']/Key[@name='Google']/descendant-or-self::*")
+ForEach ($childNodes in $parentNode) {
+    $childNodes.SetAttribute("isolation", "Full")
+}
+
+# set net.spoon.chromenativehost key to merge isolation, so Turbo VM Extension is able to establish connection with a message host installed natively
+$userChromeKey = $Registry.SelectSingleNode("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Google']/Key[@name='Chrome']")
+if (-not $userChromeKey) {
+    AddRegKey "Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Google']" "Chrome" "Full" "False" "False"
+}
+AddRegKey "Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Google']/Key[@name='Chrome']" "NativeMessagingHosts" "Full" "False" "False"
+AddRegKey "Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Google']/Key[@name='Chrome']/Key[@name='NativeMessagingHosts']" "net.spoon.chromenativehost" "Merge" "False" "False"
+
+# Delete registry keys - unnecessary keys
+$Registry.SelectNodes("Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='Microsoft']/Key[@name='Active Setup']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+$Registry.SelectNodes("Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='Microsoft']/Key[@name='MediaPlayer']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+
+
+# Add reg key HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall and set to Full Isolation
+# This will prevent Chrome Apps from creating Programs and Features entries
+$uninstallNode = $Registry.SelectSingleNode("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Microsoft']/Key[@name='Windows']/Key[@name='CurrentVersion']/Key[@name='Uninstall']")
+if (-not $uninstallNode) {
+    AddRegKey "Key[@name='@HKCU@']/Key[@name='Software']" "Microsoft" "WriteCopy" "False" "False"
+    AddRegKey "Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Microsoft']" "Windows" "WriteCopy" "False" "False"
+    AddRegKey "Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Microsoft']/Key[@name='Windows']" "CurrentVersion" "WriteCopy" "False" "False"
+    AddRegKey "Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Microsoft']/Key[@name='Windows']/Key[@name='CurrentVersion']" "Uninstall" "Full" "False" "False"
+}
+$Registry.SelectSingleNode("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Microsoft']/Key[@name='Windows']/Key[@name='CurrentVersion']/Key[@name='Uninstall']").isolation = "Full"
+
+# This will add the ProgIDs for HTTP and HTTPS allowing users to set Chrome as the default browser
+# Create Classes reg keys for http and https
+AddRegKey "Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='Classes']" "http" "Full" "False" "False"
+AddRegValue "Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='Classes']/Key[@name='http']" "URL Protocol" "Full" "False" "False" "String" ""
+AddRegKey "Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='Classes']" "https" "Full" "False" "False"
+AddRegValue "Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='Classes']/Key[@name='https']" "URL Protocol" "Full" "False" "False" "String" ""
+# Clone the ChromeHTML ProgID node to http and https
+$chromeHtmlNode = $xappl.SelectSingleNode("//ProgId[@name='ChromeHTML']").CloneNode($true)
+# Modify the ProgId name and description for HTTP and HTTPS
+$httpNode = $chromeHtmlNode.Clone()
+$httpNode.SetAttribute("name", "http")
+$httpNode.SetAttribute("description", "URL:HyperText Transfer Protocol")
+$httpsNode = $chromeHtmlNode.Clone()
+$httpsNode.SetAttribute("name", "https")
+$httpsNode.SetAttribute("description", "URL:HyperText Transfer Protocol with Privacy")
+# Append HTTP and HTTPS ProgIds to the XML structure
+$xappl.SelectSingleNode("//ProgIds").AppendChild($httpNode)
+$xappl.SelectSingleNode("//ProgIds").AppendChild($httpsNode)
+# Clone the OPEN verb to TURBOCLIENT_v24.2_LEGACY_PROGID for http and https ProgIDs
+$ProgIDNode = $xappl.SelectSingleNode("//ProgId[@name='http']")
+$openVerbNode = $ProgIDNode.SelectSingleNode(".//Verb[@name='open']")
+$newVerbNode = $openVerbNode.Clone()
+$newVerbNode.SetAttribute("name", "TURBOCLIENT_v24.2_LEGACY_PROGID")
+$ProgIDNode.AppendChild($newVerbNode)
+$ProgIDNode = $xappl.SelectSingleNode("//ProgId[@name='https']")
+$openVerbNode = $ProgIDNode.SelectSingleNode(".//Verb[@name='open']")
+$newVerbNode = $openVerbNode.Clone()
+$newVerbNode.SetAttribute("name", "TURBOCLIENT_v24.2_LEGACY_PROGID")
+$ProgIDNode.AppendChild($newVerbNode)

--- a/google_chrome-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/google_chrome-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -28,10 +28,16 @@ ForEach ($childNodes in $parentNode) {
     $childNodes.SetAttribute("noSync", "False")
 }
 
-# Sets Isolation on the folders
-$Filesystem.SelectSingleNode("Directory[@name='@APPDATALOCAL@']/Directory[@name='Google']").isolation = "Full"
-$Filesystem.SelectSingleNode("Directory[@name='@PROGRAMFILESX86@']/Directory[@name='Google']").isolation = "Full"
-$Filesystem.SelectSingleNode("Directory[@name='@PROGRAMFILES@']/Directory[@name='Google']").isolation = "Full"
+# Sets Isolation on the folders. Null-guarded because the ARM64 capture does not
+# produce all of these -- there is no Program Files (x86)\Google dir on the ARM64
+# install, and dereferencing the missing node kills the whole post-capture step.
+foreach ($googleDirPath in @(
+    "Directory[@name='@APPDATALOCAL@']/Directory[@name='Google']",
+    "Directory[@name='@PROGRAMFILESX86@']/Directory[@name='Google']",
+    "Directory[@name='@PROGRAMFILES@']/Directory[@name='Google']")) {
+    $googleDir = $Filesystem.SelectSingleNode($googleDirPath)
+    if ($googleDir) { $googleDir.isolation = "Full" }
+}
 
 #################
 # Edit Registry #

--- a/google_chrome-arm64/SupportFiles/initial_preferences
+++ b/google_chrome-arm64/SupportFiles/initial_preferences
@@ -1,0 +1,31 @@
+{
+  "homepage": "http://www.google.com",
+  "homepage_is_newtabpage": false,
+  "browser": {
+    "show_home_button": true
+  },
+  "bookmark_bar": {
+    "show_on_all_tabs": true
+  },
+  "sync_promo": {
+    "show_on_first_run_allowed": false
+  },
+  "distribution": {
+    "import_bookmarks_from_file": "bookmarks.html",
+    "import_bookmarks": true,
+    "import_history": true,
+    "import_home_page": true,
+    "import_search_engine": true,
+    "ping_delay": 60,
+    "suppress_first_run_bubble": true,
+    "do_not_create_desktop_shortcut": true,
+    "do_not_create_quick_launch_shortcut": true,
+    "do_not_launch_chrome": true,
+    "do_not_register_for_update_launch": true,
+    "make_chrome_default": false,
+    "make_chrome_default_for_user": false,
+    "suppress_first_run_default_browser_prompt": true,
+    "system_level": true,
+    "verbose_logging": true
+  }
+}

--- a/google_chrome-arm64/VersionCheck.ps1
+++ b/google_chrome-arm64/VersionCheck.ps1
@@ -1,0 +1,25 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$release = Invoke-RestMethod "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Windows&num=1"
+$LatestWebVersion = RemoveTrailingZeros $release[0].version
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/microsoft_dotnet-aspnet-runtime-arm64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-aspnet-runtime-arm64/BuildTurboImage.ps1
@@ -62,9 +62,12 @@ $InstalledVersion = RemoveTrailingZeros $LatestVersion
 $LatestMajorVer = ($LatestVersion -split '\.')[0]
 WriteLog "Latest Version: $LatestVersion"
 
-# We will use the winget image from Turbo.net to download and install this app
-WriteLog "Pulling microsoft/winget from Turbo.net"
-turbo pull --format=json microsoft/winget
+# The x64 variant installs via the microsoft/winget Turbo image, but that container does
+# not run on the Windows-on-ARM capture VMs (turbo try exits -1 immediately). Download
+# the ARM64 installer directly instead; same source the winget manifest points at.
+$InstallerName = "aspnetcore-runtime-$LatestVersion-win-arm64.exe"
+$DownloadLink = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/$LatestVersion/$InstallerName"
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 
 #########################
 ## Start Turbo Capture ##
@@ -77,9 +80,7 @@ StartTurboCapture
 #############################
 WriteLog "Installing the application."
 
-$turboCmd = "try winget --isolate=merge -- /C winget install Microsoft.DotNet.AspNetCore.$LatestMajorVer -a arm64 --silent --accept-source-agreements"
-
-$ProcessExitCode = RunProcess "turbo" $turboCmd $True
+$ProcessExitCode = RunProcess $Installer "/install /quiet /norestart" $True
 CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
 
 ################################

--- a/microsoft_dotnet-aspnet-runtime-arm64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-aspnet-runtime-arm64/BuildTurboImage.ps1
@@ -1,0 +1,117 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Microsoft"
+$AppDesc = "This runtime runs web server apps and provides many web-related APIs. ASP.NET Core Runtime allows you to run apps that were made with .NET that didn't provide the runtime. You must install .NET Runtime in addition to this runtime."
+$AppName = "ASP.NET Core Runtime (ARM64)"
+$VendorURL = "https://dotnet.microsoft.com/en-us/download/dotnet"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-release'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
+
+# We will use the winget image from Turbo.net to download and install this app
+WriteLog "Pulling microsoft/winget from Turbo.net"
+turbo pull --format=json microsoft/winget
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$turboCmd = "try winget --isolate=merge -- /C winget install Microsoft.DotNet.AspNetCore.$LatestMajorVer -a arm64 --silent --accept-source-agreements"
+
+$ProcessExitCode = RunProcess "turbo" $turboCmd $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Add any additional customization here
+
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/microsoft_dotnet-aspnet-runtime-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/microsoft_dotnet-aspnet-runtime-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,24 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+
+###################
+# Edit Filesystem #
+###################
+
+# Remove the Turbo folders that get captured
+$Filesystem.SelectNodes("Directory[@name='@APPDATACOMMON@']/Directory[@name='Turbo']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+
+# Remove the WinGet folders that get captured
+$Filesystem.SelectNodes("Directory[@name='@APPDATALOCAL@']/Directory[@name='Microsoft']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+
+####################
+# Environment Vars #
+####################
+
+$EnvironmentVariablesEx = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("EnvironmentVariablesEx")
+# Add the dotnet directory to the PATH env var
+AddEnvVar "PATH" "Inherit" "Prepend" ";" "@PROGRAMFILES@\dotnet"
+# Specifies whether .NET welcome and telemetry messages are displayed on the first run.
+# https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_nologo
+AddEnvVar "DOTNET_NOLOGO" "Inherit" "Replace" "" "true"

--- a/microsoft_dotnet-aspnet-runtime-arm64/VersionCheck.ps1
+++ b/microsoft_dotnet-aspnet-runtime-arm64/VersionCheck.ps1
@@ -1,0 +1,29 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros $latestStable.'latest-release'
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/microsoft_dotnet-desktop-runtime-arm64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-desktop-runtime-arm64/BuildTurboImage.ps1
@@ -62,9 +62,12 @@ $InstalledVersion = RemoveTrailingZeros $LatestVersion
 $LatestMajorVer = ($LatestVersion -split '\.')[0]
 WriteLog "Latest Version: $LatestVersion"
 
-# We will use the winget image from Turbo.net to download and install this app
-WriteLog "Pulling microsoft/winget from Turbo.net"
-turbo pull --format=json microsoft/winget
+# The x64 variant installs via the microsoft/winget Turbo image, but that container does
+# not run on the Windows-on-ARM capture VMs (turbo try exits -1 immediately). Download
+# the ARM64 installer directly instead; same source the winget manifest points at.
+$InstallerName = "windowsdesktop-runtime-$LatestVersion-win-arm64.exe"
+$DownloadLink = "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/$LatestVersion/$InstallerName"
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 
 #########################
 ## Start Turbo Capture ##
@@ -77,9 +80,7 @@ StartTurboCapture
 #############################
 WriteLog "Installing the application."
 
-$turboCmd = "try winget --isolate=merge -- /C winget install Microsoft.DotNet.DesktopRuntime.$LatestMajorVer -a arm64 --silent --accept-source-agreements"
-
-$ProcessExitCode = RunProcess "turbo" $turboCmd $True
+$ProcessExitCode = RunProcess $Installer "/install /quiet /norestart" $True
 CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
 
 ################################

--- a/microsoft_dotnet-desktop-runtime-arm64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-desktop-runtime-arm64/BuildTurboImage.ps1
@@ -1,0 +1,117 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Microsoft"
+$AppDesc = "The .NET Desktop Runtime enables you to run existing Windows desktop applications. This release includes the .NET Runtime; you don't need to install it separately."
+$AppName = ".NET Desktop Runtime (ARM64)"
+$VendorURL = "https://dotnet.microsoft.com/en-us/download/dotnet"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-release'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
+
+# We will use the winget image from Turbo.net to download and install this app
+WriteLog "Pulling microsoft/winget from Turbo.net"
+turbo pull --format=json microsoft/winget
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$turboCmd = "try winget --isolate=merge -- /C winget install Microsoft.DotNet.DesktopRuntime.$LatestMajorVer -a arm64 --silent --accept-source-agreements"
+
+$ProcessExitCode = RunProcess "turbo" $turboCmd $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Add any additional customization here
+
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/microsoft_dotnet-desktop-runtime-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/microsoft_dotnet-desktop-runtime-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,25 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+
+###################
+# Edit Filesystem #
+###################
+
+# Remove the Turbo folders that get captured
+$Filesystem.SelectNodes("Directory[@name='@APPDATACOMMON@']/Directory[@name='Turbo']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+
+# Remove the WinGet folders that get captured
+$Filesystem.SelectNodes("Directory[@name='@APPDATALOCAL@']/Directory[@name='Microsoft']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+
+
+####################
+# Environment Vars #
+####################
+
+$EnvironmentVariablesEx = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("EnvironmentVariablesEx")
+# Add the dotnet directory to the PATH env var
+AddEnvVar "PATH" "Inherit" "Prepend" ";" "@PROGRAMFILES@\dotnet"
+# Specifies whether .NET welcome and telemetry messages are displayed on the first run.
+# https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_nologo
+AddEnvVar "DOTNET_NOLOGO" "Inherit" "Replace" "" "true"

--- a/microsoft_dotnet-desktop-runtime-arm64/VersionCheck.ps1
+++ b/microsoft_dotnet-desktop-runtime-arm64/VersionCheck.ps1
@@ -1,0 +1,29 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros $latestStable.'latest-release'
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/microsoft_dotnet-runtime-arm64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-runtime-arm64/BuildTurboImage.ps1
@@ -1,0 +1,117 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Microsoft"
+$AppDesc = "This is the base runtime, and contains just the components needed to run a console app"
+$AppName = ".NET Runtime (ARM64)"
+$VendorURL = "https://dotnet.microsoft.com/en-us/download/dotnet"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-release'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+$LatestMajorVer = ($LatestVersion -split '\.')[0]
+WriteLog "Latest Version: $LatestVersion"
+
+# We will use the winget image from Turbo.net to download and install this app
+WriteLog "Pulling microsoft/winget from Turbo.net"
+turbo pull --format=json microsoft/winget
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$turboCmd = "try winget --isolate=merge -- /C winget install Microsoft.DotNet.Runtime.$LatestMajorVer -a arm64 --silent --accept-source-agreements"
+
+$ProcessExitCode = RunProcess "turbo" $turboCmd $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Add any additional customization here
+
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/microsoft_dotnet-runtime-arm64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-runtime-arm64/BuildTurboImage.ps1
@@ -62,9 +62,12 @@ $InstalledVersion = RemoveTrailingZeros $LatestVersion
 $LatestMajorVer = ($LatestVersion -split '\.')[0]
 WriteLog "Latest Version: $LatestVersion"
 
-# We will use the winget image from Turbo.net to download and install this app
-WriteLog "Pulling microsoft/winget from Turbo.net"
-turbo pull --format=json microsoft/winget
+# The x64 variant installs via the microsoft/winget Turbo image, but that container does
+# not run on the Windows-on-ARM capture VMs (turbo try exits -1 immediately). Download
+# the ARM64 installer directly instead; same source the winget manifest points at.
+$InstallerName = "dotnet-runtime-$LatestVersion-win-arm64.exe"
+$DownloadLink = "https://builds.dotnet.microsoft.com/dotnet/Runtime/$LatestVersion/$InstallerName"
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
 
 #########################
 ## Start Turbo Capture ##
@@ -77,9 +80,7 @@ StartTurboCapture
 #############################
 WriteLog "Installing the application."
 
-$turboCmd = "try winget --isolate=merge -- /C winget install Microsoft.DotNet.Runtime.$LatestMajorVer -a arm64 --silent --accept-source-agreements"
-
-$ProcessExitCode = RunProcess "turbo" $turboCmd $True
+$ProcessExitCode = RunProcess $Installer "/install /quiet /norestart" $True
 CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
 
 ################################

--- a/microsoft_dotnet-runtime-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/microsoft_dotnet-runtime-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,27 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+###################
+# Edit Filesystem #
+###################
+
+
+
+# Remove the Turbo folders that get captured
+$Filesystem.SelectNodes("Directory[@name='@APPDATACOMMON@']/Directory[@name='Turbo']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+
+# Remove the WinGet folders that get captured
+$Filesystem.SelectNodes("Directory[@name='@APPDATALOCAL@']/Directory[@name='Microsoft']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+
+
+
+####################
+# Environment Vars #
+####################
+
+$EnvironmentVariablesEx = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("EnvironmentVariablesEx")
+# Add the dotnet directory to the PATH env var
+AddEnvVar "PATH" "Inherit" "Prepend" ";" "@PROGRAMFILES@\dotnet"
+# Specifies whether .NET welcome and telemetry messages are displayed on the first run.
+# https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_nologo
+AddEnvVar "DOTNET_NOLOGO" "Inherit" "Replace" "" "true"

--- a/microsoft_dotnet-runtime-arm64/VersionCheck.ps1
+++ b/microsoft_dotnet-runtime-arm64/VersionCheck.ps1
@@ -1,0 +1,29 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestWebVersion = RemoveTrailingZeros $latestStable.'latest-release'
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/microsoft_vscode-arm64/BuildTurboImage.ps1
+++ b/microsoft_vscode-arm64/BuildTurboImage.ps1
@@ -1,0 +1,111 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Microsoft"
+$AppDesc = "Build and debug modern web and cloud applications."
+$AppName = "Microsoft VSCode ARM64"
+$VendorURL = "https://code.visualstudio.com/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Get installer link for latest version
+$DownloadLink = "https://update.code.visualstudio.com/latest/win32-arm64/stable"
+
+# Name of the downloaded installer file
+$InstallerName = "VSCodeSetup-arm64.exe"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess "$DownloadPath\$InstallerName" "/VERYSILENT /NORESTART /MERGETASKS=!runcode" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Copy Code folder to appdata - this folder contains the settings.json configuration file that disables updates and telemetry
+Copy-Item -Path "$SupportFiles\Code" -Destination "$env:APPDATA\" -Recurse -Force
+
+
+$InstalledVersion = GetVersionFromRegistry "Microsoft Visual Studio Code"
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/microsoft_vscode-arm64/SupportFiles/Code/User/settings.json
+++ b/microsoft_vscode-arm64/SupportFiles/Code/User/settings.json
@@ -1,0 +1,9 @@
+{
+    "update.enableWindowsBackgroundUpdates": false,
+    "update.mode": "none",
+    "update.showReleaseNotes": false,
+    "telemetry.telemetryLevel": "off",
+    "window.autoDetectColorScheme": false,
+    "workbench.preferredLightColorTheme": "Visual Studio Dark",
+    "workbench.startupEditor": "none"
+}

--- a/microsoft_vscode-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/microsoft_vscode-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,20 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+# Configure vm settings
+$VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
+$VirtualizationSettings.chromiumSupport = [string]$true
+$VirtualizationSettings.shutdownProcessTree = [string]$true
+
+
+###############################
+# Edit Named Object Isolation #
+###############################
+
+# Isolate the vscode basednamedojbect to allow running multiple instances side-by-side.
+# Pipe is versioned, ex 39ba74c1-1.90.2-main-sock, 39ba74c1-1.89.1-main-sock.
+$NamedObjectIsolation = $xappl.Configuration.SelectSingleNode("NamedObjectIsolation")
+
+$node = $xappl.CreateElement("Exception")
+$node.SetAttribute("regex","main-sock")
+$NamedObjectIsolation.AppendChild($node)

--- a/microsoft_vscode-arm64/VersionCheck.ps1
+++ b/microsoft_vscode-arm64/VersionCheck.ps1
@@ -1,0 +1,36 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use this section to get the latest version 
+# either from the vendor website or the downloaded installer file
+
+# Get installer link for latest version
+$DownloadLink = "https://update.code.visualstudio.com/latest/win32-arm64/stable"
+
+# Name of the downloaded installer file
+$InstallerName = "VSCodeSetup-arm64.exe"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = Get-VersionFromExe "$Installer"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/mozilla_firefox-arm64/BuildTurboImage.ps1
+++ b/mozilla_firefox-arm64/BuildTurboImage.ps1
@@ -1,0 +1,129 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Mozilla"
+$AppDesc = "Mozillas popular open source browser enhanced for performance, privacy, and functionality."
+$AppName = "Firefox ARM64"
+$VendorURL = "https://www.mozilla.org/en-US/firefox/new/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Get installer link for latest version
+$DownloadLink = "https://download.mozilla.org/?product=firefox-latest&os=win64-aarch64&lang=en-US"
+
+# Name of the downloaded installer file
+$InstallerName = "FirefoxSetup.exe"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Install the application
+$ProcessExitCode = RunProcess $Installer "-ms /MaintenanceService=false /TaskbarShortcut=false /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+# Create ProgIDs for http and https
+$ProcessExitCode = RunProcess "C:\Program Files\Mozilla Firefox\uninstall\helper.exe" "/SetAsDefaultAppUser" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $False # Proceed on install error
+$ProcessExitCode = RunProcess "C:\Program Files\Mozilla Firefox\uninstall\helper.exe" "/SetAsDefaultAppGlobal" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $False # Proceed on install error
+
+# Copy policies.json - to C:\Program Files\Mozilla Firefox\distribution
+Copy-Item "$SupportFiles\distribution" -Destination "C:\Program Files\Mozilla Firefox\"  -Recurse -Force
+# Copy mozilla.cfg - to C:\Program Files\Mozilla Firefox
+Copy-Item "$SupportFiles\mozilla.cfg" -Destination "C:\Program Files\Mozilla Firefox\"  -Recurse -Force
+# Copy local-settings.js - to C:\Program Files\Mozilla Firefox\defaults\pref
+Copy-Item "$SupportFiles\defaults" -Destination "C:\Program Files\Mozilla Firefox\"  -Recurse -Force
+
+# Delete all values under HKCU\SOFTWARE\Mozilla\Firefox\Launcher
+&reg.exe delete "HKCU\SOFTWARE\Mozilla\Firefox\Launcher" /va /f
+# Add back the Browser key.  This resolves an issue launching web pages.
+&reg.exe add "HKCU\SOFTWARE\Mozilla\Firefox\Launcher" /t REG_QWORD /d 0 /v "C:\Program Files\Mozilla Firefox\firefox.exe|Browser" /f
+
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+
+$InstalledVersion = GetVersionFromRegistry "Firefox"
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/mozilla_firefox-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/mozilla_firefox-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,34 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+# Configure vm settings
+$VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
+$VirtualizationSettings.chromiumSupport = [string]$true
+
+
+#################
+# Edit Registry #
+#################
+## NOTE: Beware of case sensitivity when making registry changes.  eg. The registry value type "String" requires an upper-case 'S'
+##       When specifying a registry value, "OpenWithProgids" is different from "OpenWithProgIds"
+
+
+# Set Full isolation on HKCU\SOFTWARE\Mozilla\Firefox\Launcher - This fixes an issue loading web pages if Firefox is installed natively
+$Registry.SelectSingleNode("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Mozilla']/Key[@name='Firefox']/Key[@name='Launcher']").isolation= "Full"
+
+
+#################
+# Other Changes #
+#################
+
+# Clone the OPEN verb to TURBOCLIENT_v24.2_LEGACY_PROGID for http and https ProgIDs
+$ProgIDNode = $xappl.SelectSingleNode("//ProgId[@name='http']")
+$openVerbNode = $ProgIDNode.SelectSingleNode(".//Verb[@name='open']")
+$newVerbNode = $openVerbNode.Clone()
+$newVerbNode.SetAttribute("name", "TURBOCLIENT_v24.2_LEGACY_PROGID")
+$ProgIDNode.AppendChild($newVerbNode)
+$ProgIDNode = $xappl.SelectSingleNode("//ProgId[@name='https']")
+$openVerbNode = $ProgIDNode.SelectSingleNode(".//Verb[@name='open']")
+$newVerbNode = $openVerbNode.Clone()
+$newVerbNode.SetAttribute("name", "TURBOCLIENT_v24.2_LEGACY_PROGID")
+$ProgIDNode.AppendChild($newVerbNode)

--- a/mozilla_firefox-arm64/SupportFiles/defaults/pref/local-settings.js
+++ b/mozilla_firefox-arm64/SupportFiles/defaults/pref/local-settings.js
@@ -1,0 +1,3 @@
+// This file tells Firefox to use the mozilla.cfg preferences file
+pref("general.config.filename", "mozilla.cfg");
+pref("general.config.obscure_value", 0);

--- a/mozilla_firefox-arm64/SupportFiles/distribution/policies.json
+++ b/mozilla_firefox-arm64/SupportFiles/distribution/policies.json
@@ -1,0 +1,11 @@
+{
+  "policies": {
+    "DisableAppUpdate": true,
+    "DisableProfileRefresh": true,
+    "DisableTelemetry": true,
+    "DisableFirefoxStudies": true,
+    "DontCheckDefaultBrowser": true,
+    "OverrideFirstRunPage": "",
+    "OverridePostUpdatePage": ""
+  }
+}

--- a/mozilla_firefox-arm64/SupportFiles/mozilla.cfg
+++ b/mozilla_firefox-arm64/SupportFiles/mozilla.cfg
@@ -1,0 +1,3 @@
+// Use this file to set pref, defaultPref and lockPref settings
+pref("termsofuse.bypassNotification", true); // prevents first launch terms of use prompt
+pref("browser.startup.couldRestoreSession.count", 2); // prevents tab restore infobar on second launch

--- a/mozilla_firefox-arm64/VersionCheck.ps1
+++ b/mozilla_firefox-arm64/VersionCheck.ps1
@@ -1,0 +1,31 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use this section to get the latest version 
+# either from the vendor website or the downloaded installer file
+
+# Get latest version from release notes page
+$Page = curl 'https://product-details.mozilla.org/1.0/firefox_versions.json' -UseBasicParsing
+$jsonData = $Page.Content | ConvertFrom-Json
+$LatestWebVersion = $jsonData.LATEST_FIREFOX_VERSION
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/nodejs_nodejs-arm64/BuildTurboImage.ps1
+++ b/nodejs_nodejs-arm64/BuildTurboImage.ps1
@@ -79,8 +79,11 @@ StartTurboCapture
 #############################
 WriteLog "Installing the application."
 
-# Install the VCRedist ARM64
-$ProcessExitCode = RunProcess "$DownloadPath\vc_redist.arm64.exe" "/S" $True
+# Install the VCRedist ARM64. /norestart matters: the redist is a WiX burn bundle and
+# burn's silent mode will otherwise initiate a required reboot on its own, which kills
+# the capture VM mid-run (the runner drops offline and the job dies with
+# "runner lost communication").
+$ProcessExitCode = RunProcess "$DownloadPath\vc_redist.arm64.exe" "/install /quiet /norestart" $True
 CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
 
 # Install the application

--- a/nodejs_nodejs-arm64/BuildTurboImage.ps1
+++ b/nodejs_nodejs-arm64/BuildTurboImage.ps1
@@ -1,0 +1,121 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "OpenJS"
+$AppDesc = "As an asynchronous event-driven JavaScript runtime, Node.js is designed to build scalable network applications."
+$AppName = "Node.js"
+$VendorURL = "https://nodejs.org/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Use the vendor index to get the version
+$nodejsIndex = Invoke-WebRequest -Uri "https://nodejs.org/dist/index.json" -UseBasicParsing | ConvertFrom-Json
+$CurrentVersion = $nodejsIndex.version[0]
+
+$DownloadLink = "https://nodejs.org/dist/$CurrentVersion/node-$CurrentVersion-arm64.msi"
+$InstallerName = "node-$CurrentVersion-arm64.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$InstalledVersion = Get-MsiProductVersion "$Installer"
+$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+
+WriteLog "Downloading the VCRedist installers."
+# Donwload the VC++2015-2022 ARM64 Redistributable
+Invoke-WebRequest -Uri https://aka.ms/vs/17/release/vc_redist.arm64.exe -OutFile "$DownloadPath\vc_redist.arm64.exe"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Install the VCRedist ARM64
+$ProcessExitCode = RunProcess "$DownloadPath\vc_redist.arm64.exe" "/S" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+# Install the application
+$ProcessExitCode = RunProcess "msiexec.exe" "/I $Installer ALLUSERS=1 /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Remove unwanted shortcuts
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Node.js\Install Additional Tools for Node.js.lnk" -Recurse -Force
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Node.js\Uninstall Node.js.lnk" -Recurse -Force
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion

--- a/nodejs_nodejs-arm64/BuildTurboImage.ps1
+++ b/nodejs_nodejs-arm64/BuildTurboImage.ps1
@@ -84,6 +84,10 @@ WriteLog "Installing the application."
 # the capture VM mid-run (the runner drops offline and the job dies with
 # "runner lost communication").
 $ProcessExitCode = RunProcess "$DownloadPath\vc_redist.arm64.exe" "/install /quiet /norestart" $True
+# 3010 = ERROR_SUCCESS_REBOOT_REQUIRED: the install succeeded and only a reboot is
+# pending. The ARM64 CRT consistently returns this on the clean win11-arm image; the
+# reboot is irrelevant inside a capture, so treat it as success.
+if ($ProcessExitCode -eq 3010) { $ProcessExitCode = 0 }
 CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
 
 # Install the application

--- a/nodejs_nodejs-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/nodejs_nodejs-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,2 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions

--- a/nodejs_nodejs-arm64/VersionCheck.ps1
+++ b/nodejs_nodejs-arm64/VersionCheck.ps1
@@ -1,0 +1,34 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use the vendor index to get the version
+$nodejsIndex = Invoke-WebRequest -Uri "https://nodejs.org/dist/index.json" -UseBasicParsing | ConvertFrom-Json
+$CurrentVersion = $nodejsIndex.version[0]
+
+$DownloadLink = "https://nodejs.org/dist/$CurrentVersion/node-$CurrentVersion-arm64.msi"
+$InstallerName = "node-$CurrentVersion-arm64.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = Get-MsiProductVersion "$Installer"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/nodejs_nodejs-lts-arm64/BuildTurboImage.ps1
+++ b/nodejs_nodejs-lts-arm64/BuildTurboImage.ps1
@@ -1,0 +1,124 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "OpenJS"
+$AppDesc = "As an asynchronous event-driven JavaScript runtime, Node.js is designed to build scalable network applications."
+$AppName = "Node.js LTS"
+$VendorURL = "https://nodejs.org/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Use the vendor index to get the version
+$nodejsIndex = Invoke-WebRequest -Uri "https://nodejs.org/dist/index.json" -UseBasicParsing | ConvertFrom-Json
+
+# Find the first version where the .lts property is not $false
+$firstLTSVersion = $nodejsIndex | Where-Object { $_.lts -ne $false } | Select-Object -First 1
+$LTSVersion = $firstLTSVersion.version
+
+$DownloadLink = "https://nodejs.org/dist/$LTSVersion/node-$LTSVersion-arm64.msi"
+$InstallerName = "node-$LTSVersion-arm64.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$InstalledVersion = Get-MsiProductVersion "$Installer"
+$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+
+WriteLog "Downloading the VCRedist installers."
+# Donwload the VC++2015-2022 ARM64 Redistributable
+Invoke-WebRequest -Uri https://aka.ms/vs/17/release/vc_redist.arm64.exe -OutFile "$DownloadPath\vc_redist.arm64.exe"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Install the VCRedist ARM64
+$ProcessExitCode = RunProcess "$DownloadPath\vc_redist.arm64.exe" "/S" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+# Install the application
+$ProcessExitCode = RunProcess "msiexec.exe" "/I $Installer ALLUSERS=1 /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Remove unwanted shortcuts
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Node.js\Install Additional Tools for Node.js.lnk" -Recurse -Force
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Node.js\Uninstall Node.js.lnk" -Recurse -Force
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion

--- a/nodejs_nodejs-lts-arm64/BuildTurboImage.ps1
+++ b/nodejs_nodejs-lts-arm64/BuildTurboImage.ps1
@@ -82,8 +82,11 @@ StartTurboCapture
 #############################
 WriteLog "Installing the application."
 
-# Install the VCRedist ARM64
-$ProcessExitCode = RunProcess "$DownloadPath\vc_redist.arm64.exe" "/S" $True
+# Install the VCRedist ARM64. /norestart matters: the redist is a WiX burn bundle and
+# burn's silent mode will otherwise initiate a required reboot on its own, which kills
+# the capture VM mid-run (the runner drops offline and the job dies with
+# "runner lost communication").
+$ProcessExitCode = RunProcess "$DownloadPath\vc_redist.arm64.exe" "/install /quiet /norestart" $True
 CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
 
 # Install the application

--- a/nodejs_nodejs-lts-arm64/BuildTurboImage.ps1
+++ b/nodejs_nodejs-lts-arm64/BuildTurboImage.ps1
@@ -87,6 +87,10 @@ WriteLog "Installing the application."
 # the capture VM mid-run (the runner drops offline and the job dies with
 # "runner lost communication").
 $ProcessExitCode = RunProcess "$DownloadPath\vc_redist.arm64.exe" "/install /quiet /norestart" $True
+# 3010 = ERROR_SUCCESS_REBOOT_REQUIRED: the install succeeded and only a reboot is
+# pending. The ARM64 CRT consistently returns this on the clean win11-arm image; the
+# reboot is irrelevant inside a capture, so treat it as success.
+if ($ProcessExitCode -eq 3010) { $ProcessExitCode = 0 }
 CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
 
 # Install the application

--- a/nodejs_nodejs-lts-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/nodejs_nodejs-lts-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,2 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions

--- a/nodejs_nodejs-lts-arm64/VersionCheck.ps1
+++ b/nodejs_nodejs-lts-arm64/VersionCheck.ps1
@@ -1,0 +1,37 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use the vendor index to get the version
+$nodejsIndex = Invoke-WebRequest -Uri "https://nodejs.org/dist/index.json" -UseBasicParsing | ConvertFrom-Json
+
+# Find the first version where the .lts property is not $false
+$firstLTSVersion = $nodejsIndex | Where-Object { $_.lts -ne $false } | Select-Object -First 1
+$LTSVersion = $firstLTSVersion.version
+
+$DownloadLink = "https://nodejs.org/dist/$LTSVersion/node-$LTSVersion-arm64.msi"
+$InstallerName = "node-$LTSVersion-arm64.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = Get-MsiProductVersion "$Installer"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/npp_notepadplusplus-arm64/BuildTurboImage.ps1
+++ b/npp_notepadplusplus-arm64/BuildTurboImage.ps1
@@ -1,0 +1,119 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Don Ho"
+$AppDesc = "Notepad++ is a free source code editor which supports several programming languages."
+$AppName = "Notepad++ ARM64"
+$VendorURL = "https://notepad-plus-plus.org/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+    
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Get main download page for application.
+$Page = curl 'https://notepad-plus-plus.org/downloads/' -UseBasicParsing
+
+# Get download page for latest version.
+$Page2 = curl ('https://notepad-plus-plus.org' + ($Page.Links | Where-Object {$_.outerHTML -like "*Current Version*"}).href) -UseBasicParsing
+
+# Get installer link for latest version.
+$DownloadLink = ($Page2.Links | Where-Object {$_.href -like "*Installer.arm64.exe*"})[0]
+
+# Name of the downloaded installer file
+$InstallerName = [System.IO.Path]::GetFileName($DownloadLink.href)
+
+$Installer = wget $DownloadLink.href -O $DownloadPath\$InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess "$DownloadPath\$InstallerName" "/S" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+## Copy config.model.xml which will disable updates
+& cmd.exe /c xcopy /Y "$SupportFiles\config.model.xml" "C:\Program Files\Notepad++"
+
+## Unregister "Edit With Notepad++" context menu DLL
+& cmd.exe /c regsvr32 /s /u "C:\Program Files\Notepad++\NppShell_06.dll"
+
+$InstalledVersion = GetVersionFromRegistry "Notepad"
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/npp_notepadplusplus-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/npp_notepadplusplus-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,13 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+########################
+# Edit ShellExtentions #
+########################
+
+$ShellExtensions = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("ShellExtensions")
+$node = $xappl.CreateElement("ShellExtension")
+$node.SetAttribute("description","Edit with Notepad++")
+$node.SetAttribute("command","@PROGRAMFILES@\Notepad++\notepad++.exe ""%1""")
+$node.SetAttribute("iconPath","@PROGRAMFILES@\Notepad++\notepad++.exe")
+$ShellExtensions.AppendChild($node)

--- a/npp_notepadplusplus-arm64/SupportFiles/config.model.xml
+++ b/npp_notepadplusplus-arm64/SupportFiles/config.model.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<NotepadPlus>
+    <ProjectPanels>
+        <ProjectPanel id="0" workSpaceFile="" />
+        <ProjectPanel id="1" workSpaceFile="" />
+        <ProjectPanel id="2" workSpaceFile="" />
+    </ProjectPanels>
+    <ColumnEditor choice="number">
+        <text content="" />
+        <number initial="-1" increase="-1" repeat="-1" leadingZeros="no" formatChoice="dec" />
+    </ColumnEditor>
+    <GUIConfigs>
+        <GUIConfig name="ToolBar" visible="yes">standard</GUIConfig>
+        <GUIConfig name="StatusBar">show</GUIConfig>
+        <GUIConfig name="TabBar" dragAndDrop="yes" drawTopBar="yes" drawInactiveTab="yes" reduce="yes" closeButton="yes" doubleClick2Close="no" vertical="no" multiLine="no" hide="no" quitOnEmpty="no" iconSetNumber="0" />
+        <GUIConfig name="ScintillaViewsSplitter">vertical</GUIConfig>
+        <GUIConfig name="UserDefineDlg" position="undocked">hide</GUIConfig>
+        <GUIConfig name="TabSetting" replaceBySpace="no" size="4" />
+        <GUIConfig name="AppPosition" x="161" y="112" width="1100" height="700" isMaximized="no" />
+        <GUIConfig name="FindWindowPosition" left="0" top="0" right="0" bottom="0" isLessModeOn="no" />
+        <GUIConfig name="FinderConfig" wrappedLines="no" purgeBeforeEverySearch="no" showOnlyOneEntryPerFoundLine="yes" />
+        <GUIConfig name="noUpdate">yes</GUIConfig>
+        <GUIConfig name="Auto-detection">yes</GUIConfig>
+        <GUIConfig name="CheckHistoryFiles">no</GUIConfig>
+        <GUIConfig name="TrayIcon">no</GUIConfig>
+        <GUIConfig name="MaitainIndent">yes</GUIConfig>
+        <GUIConfig name="TagsMatchHighLight" TagAttrHighLight="yes" HighLightNonHtmlZone="no">yes</GUIConfig>
+        <GUIConfig name="RememberLastSession">yes</GUIConfig>
+        <GUIConfig name="DetectEncoding">yes</GUIConfig>
+        <GUIConfig name="SaveAllConfirm">yes</GUIConfig>
+        <GUIConfig name="NewDocDefaultSettings" format="0" encoding="4" lang="0" codepage="-1" openAnsiAsUTF8="yes" />
+        <GUIConfig name="langsExcluded" gr0="0" gr1="0" gr2="0" gr3="0" gr4="0" gr5="0" gr6="0" gr7="0" gr8="0" gr9="0" gr10="0" gr11="0" gr12="0" langMenuCompact="yes" />
+        <GUIConfig name="Print" lineNumber="yes" printOption="3" headerLeft="" headerMiddle="" headerRight="" footerLeft="" footerMiddle="" footerRight="" headerFontName="" headerFontStyle="0" headerFontSize="0" footerFontName="" footerFontStyle="0" footerFontSize="0" margeLeft="0" margeRight="0" margeTop="0" margeBottom="0" />
+        <GUIConfig name="Backup" action="0" useCustumDir="no" dir="" isSnapshotMode="yes" snapshotBackupTiming="7000" />
+        <GUIConfig name="TaskList">yes</GUIConfig>
+        <GUIConfig name="MRU">yes</GUIConfig>
+        <GUIConfig name="URL">2</GUIConfig>
+        <GUIConfig name="uriCustomizedSchemes">svn:// cvs:// git:// imap:// irc:// irc6:// ircs:// ldap:// ldaps:// news: telnet:// gopher:// ssh:// sftp:// smb:// skype: snmp:// spotify: steam:// sms: slack:// chrome:// bitcoin:</GUIConfig>
+        <GUIConfig name="globalOverride" fg="no" bg="no" font="no" fontSize="no" bold="no" italic="no" underline="no" />
+        <GUIConfig name="auto-completion" autoCAction="3" triggerFromNbChar="1" autoCIgnoreNumbers="yes" insertSelectedItemUseENTER="yes" insertSelectedItemUseTAB="yes" funcParams="yes" />
+        <GUIConfig name="auto-insert" parentheses="no" brackets="no" curlyBrackets="no" quotes="no" doubleQuotes="no" htmlXmlTag="no" />
+        <GUIConfig name="sessionExt"></GUIConfig>
+        <GUIConfig name="workspaceExt"></GUIConfig>
+        <GUIConfig name="MenuBar">show</GUIConfig>
+        <GUIConfig name="Caret" width="1" blinkRate="600" />
+        <GUIConfig name="ScintillaGlobalSettings" enableMultiSelection="no" />
+        <GUIConfig name="openSaveDir" value="0" defaultDirPath="" />
+        <GUIConfig name="titleBar" short="no" />
+        <GUIConfig name="insertDateTime" customizedFormat="yyyy-MM-dd HH:mm:ss" reverseDefaultOrder="no" />
+        <GUIConfig name="wordCharList" useDefault="yes" charsAdded="" />
+        <GUIConfig name="delimiterSelection" leftmostDelimiter="40" rightmostDelimiter="41" delimiterSelectionOnEntireDocument="no" />
+        <GUIConfig name="largeFileRestriction" fileSizeMB="200" isEnabled="yes" allowAutoCompletion="no" allowBraceMatch="no" allowSmartHilite="no" allowClickableLink="no" deactivateWordWrap="yes" />
+        <GUIConfig name="multiInst" setting="0" />
+        <GUIConfig name="MISC" fileSwitcherWithoutExtColumn="yes" fileSwitcherExtWidth="50" fileSwitcherWithoutPathColumn="yes" fileSwitcherPathWidth="50" backSlashIsEscapeCharacterForSql="yes" writeTechnologyEngine="0" isFolderDroppedOpenFiles="no" docPeekOnTab="no" docPeekOnMap="no" sortFunctionList="no" saveDlgExtFilterToAllTypes="no" muteSounds="no" enableFoldCmdToggable="no" hideMenuRightShortcuts="no" />
+        <GUIConfig name="Searching" monospacedFontFindDlg="no" fillFindFieldWithSelected="yes" fillFindFieldSelectCaret="yes" findDlgAlwaysVisible="no" confirmReplaceInAllOpenDocs="yes" replaceStopsWithoutFindingNext="no" />
+        <GUIConfig name="searchEngine" searchEngineChoice="2" searchEngineCustom="" />
+        <GUIConfig name="MarkAll" matchCase="no" wholeWordOnly="yes" />
+        <GUIConfig name="SmartHighLight" matchCase="no" wholeWordOnly="yes" useFindSettings="no" onAnotherView="no">yes</GUIConfig>
+        <GUIConfig name="DarkMode" enable="no" colorTone="0" customColorTop="2105376" customColorMenuHotTrack="4210752" customColorActive="4210752" customColorMain="2105376" customColorError="176" customColorText="14737632" customColorDarkText="12632256" customColorDisabledText="8421504" customColorLinkText="65535" customColorEdge="6579300" customColorHotEdge="10197915" customColorDisabledEdge="4737096" enableWindowsMode="no" darkThemeName="DarkModeDefault.xml" darkToolBarIconSet="0" darkTabIconSet="2" darkTabUseTheme="no" lightThemeName="" lightToolBarIconSet="4" lightTabIconSet="0" lightTabUseTheme="yes" />
+        <GUIConfig name="ScintillaPrimaryView" lineNumberMargin="show" lineNumberDynamicWidth="yes" bookMarkMargin="show" indentGuideLine="show" folderMarkStyle="box" isChangeHistoryEnabled="yes" lineWrapMethod="aligned" currentLineIndicator="1" currentLineFrameWidth="1" virtualSpace="no" scrollBeyondLastLine="yes" rightClickKeepsSelection="no" disableAdvancedScrolling="no" wrapSymbolShow="hide" Wrap="no" borderEdge="yes" isEdgeBgMode="no" edgeMultiColumnPos="" zoom="0" zoom2="0" whiteSpaceShow="hide" eolShow="hide" eolMode="1" borderWidth="2" smoothFont="no" paddingLeft="0" paddingRight="0" distractionFreeDivPart="4" />
+        <GUIConfig name="DockingManager" leftWidth="200" rightWidth="200" topHeight="200" bottomHeight="200">
+            <ActiveTabs cont="0" activeTab="-1" />
+            <ActiveTabs cont="1" activeTab="-1" />
+            <ActiveTabs cont="2" activeTab="-1" />
+            <ActiveTabs cont="3" activeTab="-1" />
+        </GUIConfig>
+    </GUIConfigs>
+    <FindHistory nbMaxFindHistoryPath="10" nbMaxFindHistoryFilter="10" nbMaxFindHistoryFind="10" nbMaxFindHistoryReplace="10" matchWord="no" matchCase="no" wrap="yes" directionDown="yes" fifRecuisive="yes" fifInHiddenFolder="no" fifProjectPanel1="no" fifProjectPanel2="no" fifProjectPanel3="no" fifFilterFollowsDoc="no" fifFolderFollowsDoc="no" searchMode="0" transparencyMode="1" transparency="150" dotMatchesNewline="no" isSearch2ButtonsMode="no" regexBackward4PowerUser="no" />
+    <History nbMaxFile="10" inSubMenu="no" customLength="-1" />
+</NotepadPlus>

--- a/npp_notepadplusplus-arm64/VersionCheck.ps1
+++ b/npp_notepadplusplus-arm64/VersionCheck.ps1
@@ -1,0 +1,32 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Get main download page for application.
+$Page = Invoke-WebRequest -Uri 'https://notepad-plus-plus.org/downloads/' -UseBasicParsing
+# Get download page for latest version.
+$Page2 = Invoke-WebRequest -Uri ('https://notepad-plus-plus.org' + ($Page.Links | Where-Object {$_.outerHTML -like "*Current Version*"}).href) -UseBasicParsing
+
+# Assuming the VersionLink is /downloads/v##.##.##/ we will split out the version and remove the "v" to get only the version part of the link
+$VersionLink = ($Page2.Links | Where-Object {$_.href -like "*downloads*"})[0]
+$LatestWebVersion = $VersionLink.href.Split("/")[2] -replace "v"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}


### PR DESCRIPTION
Adds `-arm64` capture dirs for 12 apps, following the `python_python-arm64` pattern (#114): copy the x64/base dir, repoint the installer at the vendor's Windows ARM64 build, no `.applab.yml` — the `-arm64` dir suffix routes the job to the win11-arm64 pool.

**All 12 captured successfully on macmini1 and pushed to the hub.**

## Apps

| Dir | ARM64 source |
|---|---|
| `google_chrome-arm64` | `googlechromestandaloneenterprise_arm64.msi` |
| `mozilla_firefox-arm64` | `os=win64-aarch64` |
| `npp_notepadplusplus-arm64` | `npp.*.Installer.arm64.exe` |
| `git_git-arm64` | `Git-*-arm64.exe` |
| `microsoft_vscode-arm64` | `win32-arm64` channel |
| `nodejs_nodejs-arm64`, `nodejs_nodejs-lts-arm64` | `node-<ver>-arm64.msi` + arm64 vc_redist |
| `7-zip_7-zip-arm64` | `7zNNNN-arm64.exe` (no ARM64 MSI exists → exe `/S` install) |
| `microsoft_dotnet-{runtime,desktop-runtime,aspnet-runtime}-arm64` | direct `builds.dotnet.microsoft.com` win-arm64 installers |
| `eclipse_temurin-lts-arm64` | newest LTS major with windows/aarch64 assets (today JDK 21; auto-moves to 25 when Adoptium ships it) |

Excluded: **Adobe Reader** — no native Windows ARM64 build exists (x86-under-emulation only).

## ARM-specific fixes found during capture runs

- **vc_redist on WoA** (node dirs): `/S` silently reboots the capture VM (burn silent mode performs required restarts) — killed the runner mid-capture. Now `/install /quiet /norestart`, with exit 3010 (`ERROR_SUCCESS_REBOOT_REQUIRED`) mapped to success; the ARM64 CRT consistently returns it on the clean win11-arm image.
- **winget container** (dotnet dirs): the `microsoft/winget` Turbo image doesn't run on the WoA VMs (`turbo try` exits −1). Replaced with direct downloads of the same installers the winget manifests resolve to.
- **Post-capture xappl null-derefs** (chrome, git): arm64 captures don't produce the same tree as x64 (no `@PROGRAMFILESX86@\Google`, different auto-registered StartupFiles). Node lookups are now null-guarded; git adds `git-cmd.exe` as the default startup file when the capture didn't register it.

## Verification

- Discovery emits `[app-capture, win11-arm64]` for all 12 dirs; x64 entries unchanged
- Every installer URL/asset filter resolved against the live vendor and returned HTTP 200 before commit
- All 12 capture runs green on the ARM pool (final runs dispatched off `371ab60`)
- Recommend arch spot-checks on first use (e.g. node `process.arch` → `arm64`), since an amd64 payload would also capture cleanly under emulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
