### PR TITLE
Add 18 arm64 build definitions

### DIFF
--- a/eclipse_temurinjre-lts-arm64/BuildTurboImage.ps1
+++ b/eclipse_temurinjre-lts-arm64/BuildTurboImage.ps1
@@ -1,0 +1,151 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Eclipse Adoptium"
+$AppDesc = "Eclipse Temurin is the open source Java SE build based upon OpenJDK"
+$AppName = "Temurin JRE LTS ARM64"
+$VendorURL = "https://adoptium.net/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+# Get major version of the latest release
+$url = "https://api.adoptium.net/v3/info/available_releases"
+$response = curl -Uri $url -UseBasicParsing
+$jsonData = $response.Content | ConvertFrom-Json
+
+# Adoptium does not ship windows/aarch64 binaries for every LTS major (as of 2026-07 only
+# JDK/JRE 21 has them; 25 does not yet). Walk the LTS list newest-first and take the first
+# major that actually has an aarch64 Windows release, so this picks 25 automatically the
+# day those binaries appear.
+$Platform = 'windows'
+$Type = 'jre'
+$Arch = 'aarch64'
+$ReleaseInfo = $null
+foreach ($candidateMajor in ($jsonData.available_lts_releases | Sort-Object -Descending)) {
+    $Assets = Invoke-WebRequest -Uri "https://api.adoptium.net/v3/assets/latest/$candidateMajor/hotspot?architecture=$Arch&image_type=$Type&os=$Platform&vendor=eclipse" -UseBasicParsing | ConvertFrom-Json
+    if ($Assets) {
+        $latestMajorVersion = $candidateMajor
+        $ReleaseInfo = $Assets
+        break
+    }
+    WriteLog "No windows/$Arch Temurin JRE binaries for JDK $candidateMajor, trying next-oldest LTS."
+}
+if (-not $ReleaseInfo) {
+    WriteLog "No LTS major has windows/$Arch Temurin JRE binaries. Exiting."
+    WriteLog "BuildResult=failed"
+    Exit 0
+}
+
+# Download the zip
+$InstallerName = $ReleaseInfo.binary.package.name
+$DownloadLink = "https://api.adoptium.net/v3/binary/latest/$latestMajorVersion/ga/$Platform/$Arch/$Type/hotspot/normal/eclipse"
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+# Get the version from the Release json
+$majorVer = $ReleaseInfo.version.major
+$minorVer = $ReleaseInfo.version.minor
+$buildVer = $ReleaseInfo.version.build
+$InstalledVersion = "$majorVer.$minorVer.$buildVer"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+New-Item -Path "c:\Program Files" -Name "Eclipse Adoptium" -ItemType Directory
+# Extract the zip file for the install
+Expand-Archive -Path $DownloadPath\$InstallerName -DestinationPath "C:\Program Files\Eclipse Adoptium"
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Register .jar files with javaw.exe
+$InstallDir = Get-ChildItem -Path "c:\Program Files\Eclipse Adoptium" -Directory | Where-Object { $_.Name -like 'jdk*' }
+
+$regKey = "HKLM:\SOFTWARE\Classes\.jar"
+if (-not (Test-Path $regKey)) {New-Item -Path $regKey -Force | Out-Null}
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\.jar" -Name '(Default)' -Value "Eclipse Adoptium.jarfile"
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\.jar" -Name 'Content Type' -Value "application/java-archive"
+
+$regKey = "HKLM:\SOFTWARE\Classes\Eclipse Adoptium.jarfile\shell\open\command"
+if (-not (Test-Path $regKey)) {New-Item -Path $regKey -Force | Out-Null}
+Set-ItemProperty -Path $regKey -Name '(Default)' -Value "`"C:\Program Files\Eclipse Adoptium\$($InstallDir)\bin\javaw.exe`" -jar `"%1`" %*"
+
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/eclipse_temurinjre-lts-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/eclipse_temurinjre-lts-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,15 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+####################
+# Environment Vars #
+####################
+
+# Get the folder the JDK was extracted to
+$InstallDir = Get-ChildItem -Path "c:\Program Files\Eclipse Adoptium" -Directory | Where-Object { $_.Name -like 'jdk*' }
+
+$EnvironmentVariablesEx = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("EnvironmentVariablesEx")
+# Add the jdk bin directory to the PATH env var
+AddEnvVar "PATH" "Inherit" "Prepend" ";" "@PROGRAMFILES@\Eclipse Adoptium\$InstallDir\bin"
+# Add the JAVA_HOME env var
+AddEnvVar "JAVA_HOME" "Inherit" "Replace" "" "@PROGRAMFILES@\Eclipse Adoptium\$InstallDir"

--- a/eclipse_temurinjre-lts-arm64/VersionCheck.ps1
+++ b/eclipse_temurinjre-lts-arm64/VersionCheck.ps1
@@ -1,0 +1,52 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Get major version of the latest release
+$url = "https://api.adoptium.net/v3/info/available_releases"
+$response = curl -Uri $url -UseBasicParsing
+$jsonData = $response.Content | ConvertFrom-Json
+
+# Same selection as BuildTurboImage.ps1: newest LTS major that has windows/aarch64
+# JRE binaries (not every LTS gets them -- see comment there).
+$Platform = 'windows'
+$Type = 'jre'
+$Arch = 'aarch64'
+$ReleaseInfo = $null
+foreach ($candidateMajor in ($jsonData.available_lts_releases | Sort-Object -Descending)) {
+    $Assets = Invoke-WebRequest -Uri "https://api.adoptium.net/v3/assets/latest/$candidateMajor/hotspot?architecture=$Arch&image_type=$Type&os=$Platform&vendor=eclipse" -UseBasicParsing | ConvertFrom-Json
+    if ($Assets) {
+        $ReleaseInfo = $Assets
+        break
+    }
+}
+if (-not $ReleaseInfo) {
+    WriteLog "No LTS major has windows/$Arch Temurin JRE binaries. Exiting."
+    WriteLog "BuildResult=failed"
+    Exit 0
+}
+
+# Get the version from the Release json
+$majorVer = $ReleaseInfo.version.major
+$minorVer = $ReleaseInfo.version.minor
+$buildVer = $ReleaseInfo.version.build
+$LatestWebVersion = "$majorVer.$minorVer.$buildVer"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/gimp_gimp-arm64/BuildTurboImage.ps1
+++ b/gimp_gimp-arm64/BuildTurboImage.ps1
@@ -1,0 +1,177 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Gimp"
+$AppDesc = "GIMP is a freely distributed program for such tasks as photo retouching, image composition and image authoring."
+$AppName = "Gimp ARM64"
+$VendorURL = "https://www.gimp.org/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$Page = curl 'https://www.gimp.org/downloads/' -UseBasicParsing
+
+# Get installer link for latest version
+# The official GIMP 3.x installer is a single package covering x86_64 and ARM64 -
+# it installs the native ARM64 build automatically on a Windows-on-ARM capture VM
+$LatestInstaller = ($Page.Links | Where-Object {$_.href -like "*gimp*setup*.exe"})[0].href
+
+$DownloadLink = "https:" + $LatestInstaller
+
+# Name of the downloaded installer file
+$InstallerName = $LatestInstaller.Split("/")[-1]
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$InstalledVersion = Get-VersionFromExe $Installer
+$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Perform Full install and include desktop shortcut
+$ProcessExitCode = RunProcess $Installer "/VERYSILENT /NORESTART /TYPE=`"FULL`" /MERGETASKS=`"desktopicon`" /ALLUSERS /NOCLOSEAPPLICATIONS /NOCANCEL /SUPPRESSMSGBOXES" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Disable update check
+$gimpDirs = Get-ChildItem -Path "C:\Program Files" -Directory -Filter "gimp*"
+
+foreach ($dir in $gimpDirs) {
+# Find gimprc files only inside these folders
+$files = Get-ChildItem -Path $dir.FullName -Recurse -Filter "gimprc" -File
+
+    foreach ($file in $files) {
+        # Read the content of the file
+        $content = Get-Content -Path $file.FullName
+
+        # Replace the line if it matches "# (check-updates yes)"
+        $updatedContent = $content -replace '# \(check-updates yes\)', '(check-updates no)'
+
+        # Write the updated content back to the file
+        Set-Content -Path $file.FullName -Value $updatedContent
+
+        WriteLog "Updated file: $($file.FullName)"
+    }
+}
+
+# Launch GIMP - this will speed up first launch of a new session
+    # Define the path to the Start Menu Programs directory for all users
+    $startMenuPath = "$env:ALLUSERSPROFILE\Microsoft\Windows\Start Menu\Programs"
+
+    # Get all .lnk files in the Start Menu Programs directory and subdirectories
+    $shortcutFiles = Get-ChildItem -Path $startMenuPath -Filter *.lnk -Recurse
+
+    # Find the .lnk file that contains "GIMP" in its name
+    $gimpShortcut = $shortcutFiles | Where-Object { $_.Name -like "*GIMP*" }
+
+    # Check if the GIMP shortcut was found
+    if ($gimpShortcut) {
+        # Get the full path to the GIMP shortcut
+        $gimpShortcutPath = $gimpShortcut.FullName
+
+        # Use the Shell COM object to resolve the target path of the .lnk file
+        $shell = New-Object -ComObject WScript.Shell
+        $shortcut = $shell.CreateShortcut($gimpShortcutPath)
+        $targetPath = $shortcut.TargetPath
+
+        # Launch the target application
+        Start-Process -FilePath $targetPath
+    } else {
+        WriteLog "GIMP shortcut not found."
+    }
+
+Start-Sleep -Seconds 90
+
+# Send the ESC Key to close the GIMP Welcome window - this will create the gimprc file in @APPDATA@
+Add-Type -AssemblyName System.Windows.Forms
+[System.Windows.Forms.SendKeys]::SendWait("{ESC}")
+
+Start-Sleep -Seconds 5
+
+# End the GIMP application - required to create the user files in @APPDATA@
+$processes = Get-Process -Name "gimp*" -ErrorAction SilentlyContinue
+foreach ($process in $processes) {
+    $process.CloseMainWindow()
+}
+
+Start-Sleep -Seconds 20
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion

--- a/gimp_gimp-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/gimp_gimp-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,2 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions

--- a/gimp_gimp-arm64/VersionCheck.ps1
+++ b/gimp_gimp-arm64/VersionCheck.ps1
@@ -1,0 +1,37 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$Page = curl 'https://www.gimp.org/downloads/' -UseBasicParsing
+
+# Get installer link for latest version
+$LatestInstaller = ($Page.Links | Where-Object {$_.href -like "*gimp*setup*.exe"})[0].href
+
+$DownloadLink = "https:" + $LatestInstaller
+
+# Name of the downloaded installer file
+$InstallerName = $LatestInstaller.Split("/")[-1]
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = Get-VersionFromExe $Installer
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/irfanview_irfanview-arm64/BuildTurboImage.ps1
+++ b/irfanview_irfanview-arm64/BuildTurboImage.ps1
@@ -1,0 +1,142 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Irfanview"
+$AppDesc = "A fast and compact image viewer and converter."
+$AppName = "Irfanview ARM64"
+$VendorURL = "https://www.irfanview.com/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+# Parse download page for latest version.
+$Page = curl 'https://www.irfanview.com' -UseBasicParsing
+## match operator populates the $matches variable.
+$Page -match "Version (.*)</span>"
+$LatestWebVersion = $matches[1]
+$DLVersion = $LatestWebVersion -replace '\.',''
+
+$InstallerName = "iview" + $DLVersion + "_arm64_setup.exe"
+$DownloadLink = "https://www.irfanview.info/files/" + $InstallerName
+
+# Download installer - we have to use the curl.exe from System32 or you will get permission denied from the site
+WriteLog "Downloading zip from $DownloadLink"
+C:\Windows\System32\curl.exe $DownloadLink --referer "`"$DownloadLink`"" -o $DownloadPath\$InstallerName
+Start-Sleep -Seconds 20
+
+$InstalledVersion = $LatestWebVersion
+$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Perform silent MSI installation
+## silent = unattended install
+## desktop = create desktop shortcut
+## thumbs = create desktop shortcut for thumbnails
+## group = create group in Start Menu
+## allusers = install in program folder for all users
+## assoc = set file associations
+## https://www.irfanview.com/faq.htm
+$ProcessExitCode = RunProcess $DownloadPath\$InstallerName "/silent /desktop=1 /thumbs=1 /group=1 /allusers=1 /assoc=1" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Remove Uninstall shortcut from the start menu
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\Uninstall IrfanView.lnk" -Recurse -Force
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\About IrfanView.lnk" -Recurse -Force
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\Available Languages.lnk" -Recurse -Force
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\Available PlugIns.lnk" -Recurse -Force
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\Command line Options.lnk" -Recurse -Force
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\IrfanView Help.lnk" -Recurse -Force
+Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\What's New.lnk" -Recurse -Force
+
+# Capture first launch to isolate user appdata folers
+# Resolve the exe by wildcard - the arm64 build's exe name is not guaranteed to be i_view64.exe
+$IviewExe = (Get-ChildItem "C:\Program Files\IrfanView" -Filter "i_view*.exe" | Select-Object -First 1)
+RunProcess $IviewExe.FullName $Null $False
+Start-Sleep -Seconds 60
+# Stop application
+RunProcess "taskkill.exe" "/im $($IviewExe.Name)" $True
+
+Start-Sleep -Seconds 90
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion

--- a/irfanview_irfanview-arm64/BuildTurboImage.ps1
+++ b/irfanview_irfanview-arm64/BuildTurboImage.ps1
@@ -59,7 +59,7 @@ $Page -match "Version (.*)</span>"
 $LatestWebVersion = $matches[1]
 $DLVersion = $LatestWebVersion -replace '\.',''
 
-$InstallerName = "iview" + $DLVersion + "_arm64_setup.exe"
+$InstallerName = "iview" + $DLVersion + "_arm64.zip"
 $DownloadLink = "https://www.irfanview.info/files/" + $InstallerName
 
 # Download installer - we have to use the curl.exe from System32 or you will get permission denied from the site
@@ -81,40 +81,35 @@ StartTurboCapture
 #############################
 WriteLog "Installing the application."
 
-# Perform silent MSI installation
-## silent = unattended install
-## desktop = create desktop shortcut
-## thumbs = create desktop shortcut for thumbnails
-## group = create group in Start Menu
-## allusers = install in program folder for all users
-## assoc = set file associations
-## https://www.irfanview.com/faq.htm
-$ProcessExitCode = RunProcess $DownloadPath\$InstallerName "/silent /desktop=1 /thumbs=1 /group=1 /allusers=1 /assoc=1" $True
-CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
-
-# The arm64 setup exe returns exit 0 immediately and completes the install in a spawned
-# process (the x64 installer blocks until done). Wait for the install to actually land
-# before touching shortcuts or launching the app; exits the build if it never appears.
-# Wildcard because the arm64 build's exe name is not guaranteed to be i_view64.exe.
-Wait-ForFileExistence "C:\Program Files\IrfanView\i_view*.exe" -Iterations 120 -SleepTime 1
+# IrfanView's arm64 setup exe exits 0 without installing anything when run with the
+# documented silent switches, so install from the official ARM64 zip instead.
+# The binaries are ARM64EC: they report x64 in the PE header (by design, for x64
+# interop) but run natively on ARM64 - verified via the CHPE metadata pointer.
+New-Item -Path "C:\Program Files" -Name "IrfanView" -ItemType Directory
+Expand-Archive -Path $DownloadPath\$InstallerName -DestinationPath "C:\Program Files\IrfanView"
 
 ################################
 ## Customize the application  ##
 ################################
 WriteLog "Performing post-install customizations."
 
-# Remove Uninstall shortcut from the start menu
-Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\Uninstall IrfanView.lnk" -Recurse -Force
-Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\About IrfanView.lnk" -Recurse -Force
-Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\Available Languages.lnk" -Recurse -Force
-Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\Available PlugIns.lnk" -Recurse -Force
-Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\Command line Options.lnk" -Recurse -Force
-Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\IrfanView Help.lnk" -Recurse -Force
-Remove-Item -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\What's New.lnk" -Recurse -Force
-
-# Capture first launch to isolate user appdata folers
 # Resolve the exe by wildcard - the arm64 build's exe name is not guaranteed to be i_view64.exe
 $IviewExe = (Get-ChildItem "C:\Program Files\IrfanView" -Filter "i_view*.exe" | Select-Object -First 1)
+
+# The zip install creates no shortcuts - create the Start Menu and Desktop shortcuts
+# the x64 installer would have created (the x64 recipe instead deletes the extras)
+function CreateIrfanViewShortcut($shortcutPath) {
+    $WshShell = New-Object -ComObject WScript.Shell
+    $shortcut = $WshShell.CreateShortcut($shortcutPath)
+    $shortcut.TargetPath = $IviewExe.FullName
+    $shortcut.Save()
+    WriteLog "Shortcut created: $shortcutPath"
+}
+New-Item -ItemType Directory -Force -Path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView"
+CreateIrfanViewShortcut "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\IrfanView\IrfanView.lnk"
+CreateIrfanViewShortcut "$env:USERPROFILE\Desktop\IrfanView.lnk"
+
+# Capture first launch to isolate user appdata folers
 RunProcess $IviewExe.FullName $Null $False
 Start-Sleep -Seconds 60
 # Stop application

--- a/irfanview_irfanview-arm64/BuildTurboImage.ps1
+++ b/irfanview_irfanview-arm64/BuildTurboImage.ps1
@@ -92,6 +92,12 @@ WriteLog "Installing the application."
 $ProcessExitCode = RunProcess $DownloadPath\$InstallerName "/silent /desktop=1 /thumbs=1 /group=1 /allusers=1 /assoc=1" $True
 CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
 
+# The arm64 setup exe returns exit 0 immediately and completes the install in a spawned
+# process (the x64 installer blocks until done). Wait for the install to actually land
+# before touching shortcuts or launching the app; exits the build if it never appears.
+# Wildcard because the arm64 build's exe name is not guaranteed to be i_view64.exe.
+Wait-ForFileExistence "C:\Program Files\IrfanView\i_view*.exe" -Iterations 120 -SleepTime 1
+
 ################################
 ## Customize the application  ##
 ################################

--- a/irfanview_irfanview-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/irfanview_irfanview-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,12 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+## Update startup file to main IrfanView application rather than Thumbnail viewer.
+## Null-guarded and exe matched by prefix - the arm64 build's exe name is not guaranteed to be i_view64.exe
+$StartupFiles = $xappl.Configuration.SelectSingleNode("StartupFiles")
+# Set default to False for all startup files to disable them on launch.
+$defaultNode = $StartupFiles.SelectSingleNode("StartupFile[@default='True']")
+if ($defaultNode) { $defaultNode.default = 'False' }
+# Set default to True for the main application exe that doesn't have any arguments.
+$mainExeNode = $StartupFiles.SelectSingleNode("StartupFile[starts-with(@node,'@PROGRAMFILES@\IrfanView\i_view') and @commandLine='']")
+if ($mainExeNode) { $mainExeNode.SetAttribute("default", "True") }

--- a/irfanview_irfanview-arm64/VersionCheck.ps1
+++ b/irfanview_irfanview-arm64/VersionCheck.ps1
@@ -1,0 +1,30 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Parse download page for latest version.
+$Page = curl 'https://www.irfanview.com/' -UseBasicParsing
+## match operator populates the $matches variable.
+$Page -match "Version (.*)</span>"
+$LatestWebVersion = $matches[1]
+
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/irfanview_irfanview-plugins-arm64/BuildTurboImage.ps1
+++ b/irfanview_irfanview-plugins-arm64/BuildTurboImage.ps1
@@ -59,7 +59,7 @@ $Page -match "Version (.*)</span>"
 $LatestWebVersion = $matches[1]
 $DLVersion = $LatestWebVersion -replace '\.',''
 
-$InstallerName = "iview" + $DLVersion + "_plugins_arm64_setup.exe"
+$InstallerName = "iview" + $DLVersion + "_plugins_arm64.zip"
 $DownloadLink = "https://www.irfanview.info/files/" + $InstallerName
 
 # Download installer - we have to use the curl.exe from System32 or you will get permission denied from the site
@@ -72,13 +72,6 @@ $InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
 
 
 #########################
-## Pre-install Config  ##
-#########################
-
-# Plugin installer checks for the reg value below to install in the correct directory
-&reg add HKEY_CLASSES_ROOT\IrfanView\shell\open\command /v '""' /t REG_SZ /d '"""C:\Program Files\IrfanView\i_view64.exe""" """%1"""' /f
-
-#########################
 ## Start Turbo Capture ##
 #########################
 
@@ -89,17 +82,17 @@ StartTurboCapture
 #############################
 WriteLog "Installing the application."
 
-# Perform silent installation
-## silent = unattended install
-$ProcessExitCode = RunProcess $DownloadPath\$InstallerName "/silent" $True
-CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+# IrfanView's arm64 silent plugin installer does not perform an install - extract the
+# official ARM64 plugins zip (flat DLLs) into the app's Plugins directory instead.
+# The DLLs are ARM64EC: they report x64 in the PE header but run natively on ARM64.
+# The x64 recipe's pre-seeded registry key is not needed since no installer runs.
+New-Item -ItemType Directory -Force -Path "C:\Program Files\IrfanView\Plugins"
+Expand-Archive -Path $DownloadPath\$InstallerName -DestinationPath "C:\Program Files\IrfanView\Plugins"
 
 ################################
 ## Customize the application  ##
 ################################
 WriteLog "Performing post-install customizations."
-
-Start-Sleep -Seconds 90
 
 #########################
 ## Stop Turbo Capture  ##

--- a/irfanview_irfanview-plugins-arm64/BuildTurboImage.ps1
+++ b/irfanview_irfanview-plugins-arm64/BuildTurboImage.ps1
@@ -1,0 +1,127 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Irfanview"
+$AppDesc = "A fast and compact image viewer and converter."
+$AppName = "Irfanview Plugins ARM64"
+$VendorURL = "https://www.irfanview.com/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+# Parse download page for latest version.
+$Page = curl 'https://www.irfanview.com' -UseBasicParsing
+## match operator populates the $matches variable.
+$Page -match "Version (.*)</span>"
+$LatestWebVersion = $matches[1]
+$DLVersion = $LatestWebVersion -replace '\.',''
+
+$InstallerName = "iview" + $DLVersion + "_plugins_arm64_setup.exe"
+$DownloadLink = "https://www.irfanview.info/files/" + $InstallerName
+
+# Download installer - we have to use the curl.exe from System32 or you will get permission denied from the site
+WriteLog "Downloading zip from $DownloadLink"
+C:\Windows\System32\curl.exe $DownloadLink --referer "`"$DownloadLink`"" -o $DownloadPath\$InstallerName
+Start-Sleep -Seconds 20
+
+$InstalledVersion = $LatestWebVersion
+$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+
+
+#########################
+## Pre-install Config  ##
+#########################
+
+# Plugin installer checks for the reg value below to install in the correct directory
+&reg add HKEY_CLASSES_ROOT\IrfanView\shell\open\command /v '""' /t REG_SZ /d '"""C:\Program Files\IrfanView\i_view64.exe""" """%1"""' /f
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Perform silent installation
+## silent = unattended install
+$ProcessExitCode = RunProcess $DownloadPath\$InstallerName "/silent" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+Start-Sleep -Seconds 90
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion

--- a/irfanview_irfanview-plugins-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/irfanview_irfanview-plugins-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,2 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions

--- a/irfanview_irfanview-plugins-arm64/VersionCheck.ps1
+++ b/irfanview_irfanview-plugins-arm64/VersionCheck.ps1
@@ -1,0 +1,30 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Parse download page for latest version.
+$Page = curl 'https://www.irfanview.com/' -UseBasicParsing
+## match operator populates the $matches variable.
+$Page -match "Version (.*)</span>"
+$LatestWebVersion = $matches[1]
+
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/microsoft_dotnet-sdk-arm64/BuildTurboImage.ps1
+++ b/microsoft_dotnet-sdk-arm64/BuildTurboImage.ps1
@@ -1,0 +1,117 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Microsoft"
+$AppDesc = "The .NET SDK allows you to develop apps with .NET. If you install the .NET SDK, you don't need to install the corresponding runtimes."
+$AppName = ".NET SDK ARM64"
+$VendorURL = "https://dotnet.microsoft.com/en-us/download/dotnet"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$releasesIndex = Invoke-RestMethod "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+$latestStable = $releasesIndex.'releases-index' |
+    Where-Object { $_.'support-phase' -eq 'active' } |
+    Sort-Object { [version]$_.'channel-version' } -Descending |
+    Select-Object -First 1
+$LatestVersion = $latestStable.'latest-sdk'
+$InstalledVersion = RemoveTrailingZeros $LatestVersion
+WriteLog "Latest Version: $LatestVersion"
+
+# The x64 variant installs via the microsoft/winget Turbo image, but that container does
+# not run on the Windows-on-ARM capture VMs (turbo try exits -1 immediately). Download
+# the ARM64 installer directly instead; same source the winget manifest points at.
+$InstallerName = "dotnet-sdk-$LatestVersion-win-arm64.exe"
+$DownloadLink = "https://builds.dotnet.microsoft.com/dotnet/Sdk/$LatestVersion/$InstallerName"
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess $Installer "/install /quiet /norestart" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Add any additional customization here
+
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/microsoft_dotnet-sdk-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/microsoft_dotnet-sdk-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,25 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+###################
+# Edit Filesystem #
+###################
+
+
+# Remove the Turbo folders that get captured
+$Filesystem.SelectNodes("Directory[@name='@APPDATACOMMON@']/Directory[@name='Turbo']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+
+# Remove the WinGet folders that get captured
+$Filesystem.SelectNodes("Directory[@name='@APPDATALOCAL@']/Directory[@name='Microsoft']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+
+
+
+####################
+# Environment Vars #
+####################
+
+$EnvironmentVariablesEx = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("EnvironmentVariablesEx")
+# Add the dotnet directory to the PATH env var
+AddEnvVar "PATH" "Inherit" "Prepend" ";" "@PROGRAMFILES@\dotnet"
+# Specifies whether .NET welcome and telemetry messages are displayed on the first run.
+# https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_nologo
+AddEnvVar "DOTNET_NOLOGO" "Inherit" "Replace" "" "true"

--- a/microsoft_dotnet-sdk-arm64/VersionCheck.ps1
+++ b/microsoft_dotnet-sdk-arm64/VersionCheck.ps1
@@ -1,0 +1,44 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$URL = "https://versionsof.net/core/"
+$Page = Invoke-WebRequest $URL -UseBasicParsing
+
+$MajorVersions = (($Page.Links | Where-Object {$_.href -match '^/core/\d+\.\d+/$'} | Select-Object -Skip 1))
+
+ForEach ($MajorVersion in $MajorVersions) {
+ # Find the first link that doesn't have "preview"
+    if ($MajorVersion -notmatch '(?i)preview') {
+        $LatestStableVersion = ($MajorVersion -split '<a.*?>|</a>')[1]
+        Break
+    }
+}
+
+Write-Host "Latest Stable Version: $LatestStableVersion"
+
+$URL = "https://versionsof.net/core/$LatestStableVersion"
+$Page1 = Invoke-WebRequest $URL -UseBasicParsing
+$LatestWebVersion = (($Page1.Links | Where-Object {$_.outerHTML -match '>(\d+(\.\d+)*)<'})[1])
+$LatestWebVersion = ($LatestWebVersion -split '<a.*?>|</a>')[1]
+
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/microsoft_teams-arm64/BuildTurboImage.ps1
+++ b/microsoft_teams-arm64/BuildTurboImage.ps1
@@ -1,0 +1,162 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Microsoft"
+$AppDesc = "Meet, chat, and share content with anyone from anywhere in an easy and reliable way."
+$AppName = "Teams ARM64"
+$VendorURL = "https://teams.microsoft.com/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+# Download the latest MSIX
+$DownloadLink = "https://go.microsoft.com/fwlink/?linkid=2196207"
+$InstallerName = "Teams_windows_arm64.msix"
+$MSIX = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+# Download the latest teamsbootstrapper
+$DownloadLink = "https://go.microsoft.com/fwlink/?linkid=2243204&clcid=0x409"
+$InstallerName = "teamsbootstrapper.exe"
+$Bootstrapper = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+# Replace the SnapshotSettings_21.xml file to include C:\Program Files\WindowsApps folder in the capture
+New-Item -ItemType Directory -Force -Path $env:LOCALAPPDATA\Turbo.net
+Copy-Item -Path "$SupportFiles\Turbo Studio" -Destination "$env:LOCALAPPDATA\Turbo.net" -Recurse -Force
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Install Teams
+$ProcessExitCode = RunProcess $Bootstrapper "-p -o $MSIX" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+# Get the Teams installdir
+$TeamsInstallDir = (Get-AppxPackage | Where-Object {$_.Name -like "MSTeams*"}).InstallLocation
+$TeamsEXE = "$TeamsInstallDir\ms-teams.exe"
+
+# Install the MicrosoftTeamsMeetingAddinInstaller if the arm64 package ships it
+if (Test-Path "$TeamsInstallDir\MicrosoftTeamsMeetingAddinInstaller.MSI") {
+    # Get the version of the MicrosoftTeamsMeetingAddinInstaller
+    $TeamsAddInVersion = (Get-AppLockerFileInformation -Path "$TeamsInstallDir\MicrosoftTeamsMeetingAddinInstaller.MSI").Publisher.BinaryVersion
+
+    $ProcessExitCode = RunProcess "msiexec.exe" "/i `"$TeamsInstallDir\MicrosoftTeamsMeetingAddinInstaller.msi`" ALLUSERS=1 /qn /norestart TARGETDIR=`"C:\Program Files (x86)\Microsoft\TeamsMeetingAddin\$TeamsAddInVersion\`"" $True
+    CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+}
+else {
+    WriteLog "MicrosoftTeamsMeetingAddinInstaller.MSI not found in the arm64 package - skipping meeting add-in install."
+}
+
+# Disable auto updates
+&reg.exe add "HKLM\Software\Microsoft\Teams" /t REG_DWORD /d 1 /v disableAutoUpdate /f /reg:64
+
+
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Write registry keys to create the URL Protocol handlers
+New-Item -Path "HKCU:\Software\Classes\msteams\shell\open\command" -Force
+New-ItemProperty -Path "HKCU:\Software\Classes\msteams" -Name "(Default)" -Value "URL:msteams" -PropertyType String -Force
+New-ItemProperty -Path "HKCU:\Software\Classes\msteams" -Name "URL Protocol" -PropertyType String -Force
+New-ItemProperty -Path "HKCU:\Software\Classes\msteams\shell\open\command" -Name "(Default)" -Value "`"$TeamsEXE`" `"%1`"" -PropertyType String -Force
+
+New-Item -Path "HKCU:\Software\Classes\ms-teams\shell\open\command" -Force
+New-ItemProperty -Path "HKCU:\Software\Classes\ms-teams" -Name "(Default)" -Value "URL:msteams" -PropertyType String -Force
+New-ItemProperty -Path "HKCU:\Software\Classes\ms-teams" -Name "URL Protocol" -PropertyType String -Force
+New-ItemProperty -Path "HKCU:\Software\Classes\ms-teams\shell\open\command" -Name "(Default)" -Value "`"$TeamsEXE`" `"%1`"" -PropertyType String -Force
+
+# Write this key to isolate to the container to prevent Teams lauching to a blank white window
+New-Item -Path "HKCU:\Software\Classes\TeamsURL"
+
+function CreateTeamsShortcut($shortcutPath) {
+    $WshShell = New-Object -ComObject WScript.Shell
+    $shortcut = $WshShell.CreateShortcut($shortcutPath)
+    $shortcut.TargetPath = $TeamsEXE
+    $shortcut.Save()
+
+    WriteLog "Start menu shortcut created: $shortcutPath"
+}
+
+# Create Start Menu shortcut
+CreateTeamsShortcut "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Microsoft Teams (work or school).lnk"
+# Create Desktop shortcut
+CreateTeamsShortcut "$env:USERPROFILE\Desktop\Microsoft Teams (work or school).lnk"
+
+$InstalledVersion = Get-VersionFromExe $TeamsEXE
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/microsoft_teams-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/microsoft_teams-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,26 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+# Configure vm settings
+$VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
+$VirtualizationSettings.chromiumSupport = [string]$true
+
+###################
+# Edit Filesystem #
+###################
+
+
+## Add the directory path Application Data\Microsoft\Windows\Start Menu\Programs and set folder to Full isolation
+## This will prevent an issue with Teams trying to create this .lnk file on launch if the APPDATA folder is redirected to the network and the Programs folder doesn't exist
+AddDirectory "Directory[@name='@APPDATA@']" "Microsoft" "WriteCopy" "False" "False"
+AddDirectory "Directory[@name='@APPDATA@']/Directory[@name='Microsoft']" "Windows" "WriteCopy" "False" "False" "False"
+AddDirectory "Directory[@name='@APPDATA@']/Directory[@name='Microsoft']/Directory[@name='Windows']" "Start Menu" "Full" "False" "False" "False"
+AddDirectory "Directory[@name='@APPDATA@']/Directory[@name='Microsoft']/Directory[@name='Windows']/Directory[@name='Start Menu']" "Programs" "Full" "False" "False" "False"
+
+# Clone the Microsoft Teams (work or school).lnk from @PROGRAMS@ to @APPDATA@\Microsoft\Windows\Start Menu\Programs
+# Null-guarded: arm64 captures don't always produce the same filesystem tree as x64
+$fileNode = $xappl.SelectSingleNode("//File[@name='Microsoft Teams (work or school).lnk']")
+if ($fileNode) {
+    $newFileNode = $fileNode.CloneNode($true)
+    $Filesystem.SelectSingleNode("Directory[@name='@APPDATA@']/Directory[@name='Microsoft']/Directory[@name='Windows']/Directory[@name='Start Menu']/Directory[@name='Programs']").AppendChild($newFileNode)
+}

--- a/microsoft_teams-arm64/SupportFiles/Turbo Studio/SnapshotSettings_21.xml
+++ b/microsoft_teams-arm64/SupportFiles/Turbo Studio/SnapshotSettings_21.xml
@@ -1,0 +1,666 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<SnapshotSettings>
+  <Processes>
+    <Process name="Turbo-Sandbox"/>
+    <Process name="TurboService"/>
+    <Process name="Turbo-update"/>
+    <Process name="Studio"/>
+    <Process name="XStudio"/>
+
+    <!-- windows system -->
+    <Process name="system"/>
+    <Process name="consent"/>
+    <Process name="wermgr"/>
+    <Process name="cleanmgr"/>
+    <Process name="OneDriveStandaloneUpdater"/>
+    <Process name="winlogon"/>
+    <Process name="registry"/>
+    <!-- <Process name="services"/> // STD-3859 -->
+    <Process name="powermgr"/>
+    <Process name="WindowsAzureGuestAgent"/>
+    <Process name="WindowsAzureTelemetryService"/>
+    <Process name="spoolsv"/>
+    <Process name="wevtutil"/>
+    <Process name="backgroundTaskHost"/>
+    <Process name="drvinst"/>
+    <Process name="Defrag"/>
+    <Process name="SearchApp"/>
+    <Process name="StartMenuExperienceHost"/>
+    <Process name="TextInputHost"/>
+    <Process name="WmiPrvSE"/>
+    <Process name="GameBar*"/>
+    <Process name="SecurityHealthHost"/>
+    <Process name="applicationframehost"/>
+    <Process name="backgroundtransferhost"/>
+    <Process name="FindVolume"/>
+    <Process name="LogonUI"/>
+    <Process name="vmcompute"/>
+    <Process name="smartscreen"/>
+    <Process name="fontdrvhost"/>
+    <Process name="dismhost"/>
+    <Process name="tabtip"/>
+    <Process name="waappagent"/>
+    <Process name="rdpclip"/>
+    <Process name="cortana"/>
+    <Process name="NisSrv"/>
+    <Process name="UserOOBEBroker"/>
+    <Process name="VSSVC"/>
+    <Process name="wsqmcons"/>
+    <Process name="taskkill"/>
+
+    <!-- windows defender -->
+    <Process name="AM_Delta"/>
+    <Process name="AM_Base"/>
+    <Process name="AM_Engine"/>
+    <Process name="MpCmdRun"/>
+    <Process name="SgrmBroker"/>
+    <Process name="MsMpEng"/>
+    <Process name="mpengine"/>
+
+    <!-- windows update -->
+    <Process name="MoUsoCoreWorker"/>
+    <Process name="MPSigStub"/>
+    <Process name="MusNotif*"/>
+    <Process name="SIHClient"/>
+    <Process name="TiWorker"/>
+    <Process name="UpdateAssistant"/>
+    <Process name="UpdateNotificationMgr"/>
+    <Process name="usoclient"/>
+    <Process name="wuauclt"/>
+    <Process name="MicrosoftEdge*"/>
+    <Process name="wuapihost"/>
+
+    <!-- universal apps -->
+    <Process name="RuntimeBroker"/>
+    <Process name="ShellExperienceHost"/>
+
+    <!-- windows search -->
+    <Process name="SearchProtocolHost"/>
+    <Process name="SearchIndexer"/>
+    <Process name="SearchUI"/>
+    <Process name="SearchFilterHost"/>
+
+    <!-- .net -->
+    <Process name="ngentask"/>
+    <Process name="ngen"/>
+
+    <!-- apps -->
+    <Process name="msfeedssync"/>
+    <Process name="Microsoft.Photos"/>
+    <Process name="YourPhone"/>
+    <Process name="DeviceCensus"/>
+    <Process name="CompatTelRunner"/>
+    <Process name="audiodg"/>
+    <Process name="XblGameSaveTask"/>
+    <Process name="lpremove"/>
+    <Process name="ipoint"/>
+    <Process name="Dmclient"/>
+    <Process name="SecurityHealthService"/>
+    <Process name="lsass"/>
+    <Process name="dwm"/>
+    <Process name="ctfmon"/>
+    <Process name="itype"/>
+    <Process name="SettingSyncHost"/>
+    <Process name="msfeedsync"/>
+    <Process name="wmiadap"/>
+    <Process name="sihost"/>
+    <Process name="sppsvc"/>
+    <Process name="software_reporter_tool"/>
+    <Process name="scriptedsandbox64"/>
+    <Process name="procexp"/>
+    <Process name="procexp64"/>
+    <Process name="vboxservice"/>
+    <Process name="hxtsr"/>
+    <Process name="msedge"/>
+  </Processes>
+  
+  <!--Filesystem snapshot settings-->
+  <Filesystem>
+
+    <!--Set of snapshot starting-point root folders.  Removing any of these 
+        will cause it to be removed from the set of starting points.  But
+        note that sometimes we can still arrive at a deeper root by way of 
+        a shallower root, unless the path to the deeper root is excluded 
+        at some point.
+        
+        NOTE: Should order these from deepest to shallowest-->
+    <Root path="@STARTUP@" />
+    <Root path="@PROGRAMS@" />
+    <Root path="@STARTMENU@" />
+    <Root path="@DESKTOP@" />
+    <Root path="@TEMPLATES@" />
+    <Root path="@FAVORITES@" />
+    <Root path="@MUSIC@" />
+    <Root path="@PICTURES@" />
+    <Root path="@VIDEOS@" />
+    <Root path="@DOCUMENTS@" />
+    <Root path="@APPDATALOCAL@" />
+    <Root path="@APPDATALOCALLOW@" />
+    <Root path="@APPDATA@" />
+    <Root path="@PROFILE@" />
+    
+    <Root path="@STARTUPCOMMON@" />
+    <Root path="@PROGRAMSCOMMON@" />
+    <Root path="@STARTMENUCOMMON@" />
+    <Root path="@DESKTOPCOMMON@" />
+    <Root path="@TEMPLATESCOMMON@" />
+    <Root path="@FAVORITESCOMMON@" />
+    <Root path="@MUSICCOMMON@" />
+    <Root path="@PICTURESCOMMON@" />
+    <Root path="@DOCUMENTSCOMMON@" />
+    <Root path="@APPDATACOMMON@" />
+    <Root path="@PROFILECOMMON@" />
+    
+    <Root path="@PROGRAMFILESCOMMONX86@" wow64If="true" />
+    <Root path="@PROGRAMFILESX86@" wow64If="true" />
+
+    <Root path="@SYSWOW64@" wow64If="true" />
+ 
+    <Root path="@WINDIR@" />
+    <Root path="@SYSDRIVE@" />
+
+    <Exclude path="@SYSDRIVE@\Pagefile.sys" />
+    <Exclude path="@SYSDRIVE@\Boot" />
+    <Exclude path="@SYSDRIVE@\$Recycle.Bin" />
+    <Exclude path="@SYSDRIVE@\Recycler" />
+    <Exclude path="@SYSDRIVE@\Recovery" />
+    <Exclude path="@SYSDRIVE@\PerfLogs" />
+    <Exclude path="@SYSDRIVE@\System Volume Information" />
+    <Exclude path="@SYSDRIVE@\WindowsAzure" />
+    <Exclude path="@SYSDRIVE@\Packages" />
+    <!--MSOCache Created by Office installation, but massive and not needed-->
+    <Exclude path="@SYSDRIVE@\MSOCache" />
+    <Exclude path="@SYSDRIVE@\Config.msi" /> <!-- used for temp files by windows installer -->
+    
+    <Exclude path="@PROGRAMFILESX86@\Microsoft.NET\RedistList" />
+    <Exclude path="@PROGRAMFILESX86@\MSECache" />
+    <Exclude path="@PROGRAMFILESX86@\Windows XP Mode" />
+    
+    <Exclude path="@PROGRAMFILES@\Microsoft Dependency Agent" />
+    <Exclude path="@PROGRAMFILES@\UNP" />
+
+    <!--We should exclude explicit enumeration throught these paths, as 
+        required "Root" children of these - such as @PROFILE@ get 
+        added separately.-->
+    <Exclude path="@SYSDRIVE@\Documents and settings" />
+    <Exclude path="@SYSDRIVE@\Users" />
+
+    <Exclude path="@APPDATA@\Microsoft\Crypto" />
+    <Exclude path="@APPDATA@\Microsoft\Diagnosis" />
+    <Exclude path="@APPDATA@\Microsoft\Protect" />
+    <Exclude path="@APPDATA@\Microsoft\CryptnetUrlCache" />
+    <Exclude path="@APPDATA@\Microsoft\SystemCertificates" />
+    <Exclude path="@APPDATA@\Microsoft\Windows Defender" />
+    <Exclude path="@APPDATA@\Microsoft\Search" />
+    <Exclude path="@APPDATA@\Microsoft\Spelling" />
+    <Exclude path="@APPDATA@\Microsoft\RAC" />
+    <Exclude path="@APPDATA@\Microsoft\Windows" />
+    <Exclude path="@APPDATA@\Microsoft\Windows NT" />
+    <Exclude path="@APPDATA@\Microsoft\Internet Explorer" />
+    <Exclude path="@APPDATA@\Packages" />
+    <Exclude path="@APPDATA@\USOPrivate" />
+
+    <Exclude path="@APPDATACOMMON@\Microsoft\Diagnosis" />
+    <Exclude path="@APPDATACOMMON@\Microsoft\SmsRouter" />
+    <Exclude path="@APPDATACOMMON@\Packages" />
+    <Exclude path="@APPDATACOMMON@\regid.*.com.microsoft" />
+
+    <!--On XP these are used (NOTE this is not @APPDATALOCAL@, which would be @PROFILE@\Local Settings\Application Data\... on XP)-->
+    <Exclude path="@PROFILE@\ntuser.ini" />
+    <Exclude path="@PROFILE@\Cookies" />
+    <Exclude path="@PROFILE@\OneDrive" />
+    <Exclude path="@PROFILE@\Searches" />
+    <Exclude path="@PROFILE@\Recent" />
+    <!--We block all under 'Local Settings' but the specfic "Root" directores such as @APPDATALOCAL@ are added separately-->
+    <Exclude path="@PROFILE@\Local Settings" />
+    <Exclude path="@PROFILE@\AppData" />
+    <Exclude path="@PROFILE@\NTUSER.DAT" />
+    <Exclude path="@PROFILE@\NTUSER.DAT.*" />
+
+    <Exclude path="@APPDATALOCAL@\Comms" />
+    <Exclude path="@APPDATALOCAL@\ConnectedDevicesPlatform" />
+    <Exclude path="@APPDATALOCAL@\GdiPFontCacheV1.dat" />
+    <Exclude path="@APPDATALOCAL@\IconCache.db" />
+    <Exclude path="@APPDATALOCAL@\History" />
+    <Exclude path="@APPDATALOCAL@\@PUBLISHER@\Sandbox" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\CLR_v4.0\UsageLogs" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\CLR_v4.0_32\UsageLogs" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\Feeds" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\Feeds Cache" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\GameDVR" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\HelpCtr" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\Internet Explorer" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\OneDrive" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\PenWorkspace" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\RAC" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\Search" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\TokenBroker" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\Vault" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\XboxLive" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\WindowsApps" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\Windows" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\Windows Defender" />
+    <Exclude path="@APPDATALOCAL@\Microsoft\Windows NT" />
+    <Exclude path="@APPDATALOCAL@\Packages" />
+    <Exclude path="@APPDATALOCAL@\PlaceholderTilelogoFolder" />
+    <Exclude path="@APPDATALOCAL@\Publishers" />
+    <Exclude path="@APPDATALOCAL@\Spoon" />
+    <Exclude path="@APPDATALOCAL@\SquirrelTemp" />
+    <Exclude path="@APPDATALOCAL@\Temp" />
+    <Exclude path="@APPDATALOCAL@\Temporary Internet Files" />
+    <Exclude path="@APPDATALOCAL@\Turbo" />
+    <Exclude path="@APPDATALOCAL@\Turbo.net" />
+    <Exclude path="@APPDATALOCAL@\Xenocode" />
+    
+    <Exclude path="@APPDATALOCALLOW@\Microsoft" />
+
+    <Exclude path="@APPDATACOMMON@\Microsoft\DiagnosticLogCSP" />
+    <Exclude path="@APPDATACOMMON@\Microsoft\Internet Explorer" />
+    <Exclude path="@APPDATACOMMON@\Microsoft\Network\Downloader" />
+    <Exclude path="@APPDATACOMMON@\Microsoft\RAC" />
+    <Exclude path="@APPDATACOMMON@\Microsoft\Search" />
+    <Exclude path="@APPDATACOMMON@\Microsoft\Windows" />
+    <Exclude path="@APPDATACOMMON@\Microsoft\Windows Defender" />
+    <Exclude path="@APPDATACOMMON@\Microsoft\Windows NT" />
+    <Exclude path="@APPDATACOMMON@\Microsoft\Windows Security Health" />
+    <Exclude path="@APPDATACOMMON@\Microsoft OneDrive" />
+    <Exclude path="@APPDATACOMMON@\Package Cache" />
+    <Exclude path="@APPDATACOMMON@\regid.*.com.microsoft" />
+    <Exclude path="@APPDATACOMMON@\USOShared" />
+    <Exclude path="@APPDATACOMMON@\USOPrivate" />
+
+    <Exclude path="@WINDIR@\win.ini" />
+    <Exclude path="@WINDIR@\SchedLgU.Txt" />
+    <Exclude path="@WINDIR@\COM+.log" />
+    <Exclude path="@WINDIR@\0.log" />
+    <Exclude path="@WINDIR@\ShellIconCache" />
+    <Exclude path="@WINDIR@\WindowsUpdate.log" />
+    <Exclude path="@WINDIR@\wiadebug.log" />
+    <Exclude path="@WINDIR@\wiaservc.log" />
+    <Exclude path="@WINDIR@\setupact.log" />
+    <Exclude path="@WINDIR@\setupapi.log" />
+    <Exclude path="@WINDIR@\Bootstat.dat" />
+    <Exclude path="@WINDIR@\assembly\NativeImages_v4.0.30319_32" />
+    <Exclude path="@WINDIR@\assembly\NativeImages_v4.0.30319_64" />
+    <Exclude path="@WINDIR@\Migration\WTR" />
+    <Exclude path="@WINDIR@\$*" />
+    <Exclude path="@WINDIR@\AppCompat" />
+    <Exclude path="@WINDIR@\AppReadiness" />
+    <Exclude path="@WINDIR@\assembly\tmp" />
+    <Exclude path="@WINDIR@\Temp" />
+    <Exclude path="@WINDIR@\Tasks" />
+    <Exclude path="@WINDIR@\Csc" />
+    <Exclude path="@WINDIR@\Vss" />
+    <Exclude path="@WINDIR@\Inf" />
+    <Exclude path="@WINDIR@\Pla" />
+    <Exclude path="@WINDIR@\Logs" />
+    <Exclude path="@WINDIR@\Debug" />
+    <Exclude path="@WINDIR@\symbols" />
+    <Exclude path="@WINDIR@\Diagnostics" />
+    <Exclude path="@WINDIR@\Security" />
+    <Exclude path="@WINDIR@\Installer" />
+    <Exclude path="@WINDIR@\Prefetch" />
+    <Exclude path="@WINDIR@\PCHealth" />
+    <Exclude path="@WINDIR@\Performance" />
+    <Exclude path="@WINDIR@\PolicyDefinitions" />
+    <Exclude path="@WINDIR@\PrintDialog" />
+    <Exclude path="@WINDIR@\Servicing" />
+    <Exclude path="@WINDIR@\Rescache" />
+    <Exclude path="@WINDIR@\ServicePackFiles" />
+    <Exclude path="@WINDIR@\ServiceProfiles" />
+    <Exclude path="@WINDIR@\ServiceState" />
+    <Exclude path="@WINDIR@\SoftwareDistribution" />
+    <Exclude path="@WINDIR@\SystemApps" />
+    <Exclude path="@WINDIR@\XSXS" />
+    <Exclude path="@WINDIR@\WinSXS\Backup" />
+    <Exclude path="@WINDIR@\WinSXS\Catalogs" />
+    <Exclude path="@WINDIR@\WinSXS\Filemaps" />
+    <Exclude path="@WINDIR@\WinSXS\ManifestCache" />
+    <Exclude path="@WINDIR@\WinSXS\Temp" />
+    <Exclude path="@WINDIR@\Microsoft.NET\Framework\v1.0.3705\Temporary ASP.NET Files" />
+    <Exclude path="@WINDIR@\Microsoft.NET\Framework\v1.1.4322\Temporary ASP.NET Files" />
+    <Exclude path="@WINDIR@\Microsoft.NET\Framework\v2.0.50727\Temporary ASP.NET Files" />
+    <Exclude path="@WINDIR@\Microsoft.NET\Framework\v4.0.30319\ngen.log" />    
+    <Exclude path="@WINDIR@\Microsoft.NET\Framework\v4.0.30319\Temporary ASP.NET Files" />
+    <Exclude path="@WINDIR@\Microsoft.NET\Framework64\v2.0.50727\Temporary ASP.NET Files" />
+    <Exclude path="@WINDIR@\Microsoft.NET\Framework64\v4.0.30319\ngen.log" />    
+    <Exclude path="@WINDIR@\Microsoft.NET\Framework64\v4.0.30319\Temporary ASP.NET Files" />
+    <Exclude path="@WINDIR@\Microsoft.NET\Framework64\v4.0.30319\SetupCache" />
+
+    <!--Note: wow64If="true" (the default) means both @SYSTEM@ and @SYSWOW64@ will be used if applicable-->
+    <Exclude path="@SYSWOW64@\vpc-s3.cfg" />
+    <Exclude path="@SYSWOW64@\wpa.dbl" />
+    <Exclude path="@SYSWOW64@\Perf*.dat" />
+    <Exclude path="@SYSWOW64@\PerfStringBackup.ini" />
+    <Exclude path="@SYSWOW64@\Microsoft" />
+    <Exclude path="@SYSWOW64@\Winevt" />
+    <Exclude path="@SYSWOW64@\Tasks" />
+    <Exclude path="@SYSWOW64@\Spool" />
+    <Exclude path="@SYSWOW64@\Wfp" />
+    <Exclude path="@SYSWOW64@\Wbem" />
+    <Exclude path="@SYSWOW64@\Wdi" />
+    <Exclude path="@SYSWOW64@\Migwiz" />
+    <Exclude path="@SYSWOW64@\Dllcache" />
+    <Exclude path="@SYSWOW64@\DriverStore" />
+    <Exclude path="@SYSWOW64@\LogFiles" />
+    <Exclude path="@SYSWOW64@\Config" />
+    <Exclude path="@SYSWOW64@\CatRoot" />
+    <Exclude path="@SYSWOW64@\CatRoot2" />
+    <Exclude path="@SYSWOW64@\NtmsData" />
+    <Exclude path="@SYSWOW64@\spp\store" />
+    <Exclude path="@SYSWOW64@\Sysprep" />
+    <Exclude path="@SYSWOW64@\SleepStudy" />
+    <Exclude path="@SYSWOW64@\sru" />
+
+    <Exclude path="@PROGRAMS@\Turbo.net" />
+
+    <Exclude path="@STARTUP@\Turbo Sandbox Manager.lnk" />
+
+    <!--Ensure this and all child folders are set to specified isolation-->
+    <Isolation path="@SYSTEM@\mui" isolation="Merge" />
+    <Isolation path="@SYSWOW64@\mui" isolation="Merge" />
+    <Isolation path="@DOCUMENTS@" isolation="Merge" />
+    <Isolation path="@PICTURES@" isolation="Merge" />
+    <Isolation path="@MUSIC@" isolation="Merge" />
+
+  </Filesystem>
+
+  <!--Registry snapshot settings-->
+  <Registry>
+
+    <!--Set of snapshot starting point root folders.  Removing any of these 
+        will cause it to be removed from the set of starting points.  But
+        note that sometimes we can still arrive at a deeper root by way of 
+        a shallower root, unless the path to the deeper root is excluded 
+        at some point.-->
+    <Root path="@HKCU@" />
+    <Root path="@HKLM@" />
+    <Root path="@HKU@" />
+
+    <!--Excluded HKLM subkeys by default, we will select what we want
+        NOTE:  wow64If="true" (the default) causes both path flavors to be added as in: 
+            HKEY_LOCAL_MACHINE\Software\Classes\AppId and
+            HKEY_LOCAL_MACHINE\Software\Classes\Wow6432Node\AppId -->
+    <Exclude path="HKEY_LOCAL_MACHINE\*" />
+    <Include path="HKEY_LOCAL_MACHINE\Software" wow64If="false" />
+    <Include path="HKEY_LOCAL_MACHINE\System" wow64If="false" />
+
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Classes\CLSID\{4336a54d-038b-4685-ab02-99bb52d3fb8b}" /> <!-- some shell clsid that seems to be touched by every installer -->
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Classes\Local Settings" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Classes\PackagedCom\ClassIndex" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Classes\PackagedCom\Package" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Classes\Installer\Components\D1DBED127F892CE42ABE98BC42728C1D" /> <!-- OutlookSearchShellReg for Outlook 2013, VM-1765 -->
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Classes\Installer\Components\81CD10F7CB6DFEE4597F043552379067" /> <!-- OutlookSearchShellReg for Outlook 2016, VM-1765 -->
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\.NETFramework\v2.0.50727\NGenService" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\IdentityCRL" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\MemoryDiagnostic" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\MpSigStub" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Provisioning" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\RemovalTools" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\SMB1Uninstall" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Speech_OneCore" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\UNP" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Rpc" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\DrWatson" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\WBEM" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\EventSystem" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Updates" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\DirectDraw\MostRecentApplication" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Cryptography" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\PCHealth" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Ctf" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Dfrg" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Radar" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\EseNt" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\SystemCertificates" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\SqlClient" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\SqmClient" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\MMC\*" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\MMC\SnapIns" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Wab" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\WzcSvc" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Tracing" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Thinprint" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Reliability Analysis" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Security Center" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows Search\*" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows Search\ProtocolHandlers" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows Defender" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows CE Services" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Protected Storage System Provider" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows Media Device Manager" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsSelfHost" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\WindowsUpdate" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\Dwm" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\WindowsSelfhost" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\Windows Error Reporting" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\Windows Search\*" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\Windows Search\Gather" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\Windows Search\Gather\*" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\Windows Search\Gather\Windows" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\Windows Search\Gather\Windows\*" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\Windows Search\Gather\Windows\SystemIndex" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\Windows Search\Gather\Windows\SystemIndex\*" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\Windows Search\Gather\Windows\SystemIndex\Protocols" />
+    <!--Exclude all under \Windows\CurrentVersion except...-->
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\*" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\App Paths" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Explorer" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Explorer\*" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Explorer\KindMap" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Installer" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\PreviewHandlers" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnce" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Setup" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\SharedDlls" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\SideBySide" />
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\SideBySide\PublisherPolicyChangeTime" /> <!-- APPQ-2616 -->
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Explorer\Browser Helper Objects" />
+    <!--Exclude all under \Windows Nt\CurrentVersion except...-->
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows Nt\CurrentVersion\*" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows Nt\CurrentVersion\AppCompatFlags" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows Nt\CurrentVersion\Fonts" />
+    <Include path="HKEY_LOCAL_MACHINE\Software\Microsoft\Windows Nt\CurrentVersion\Image File Execution Options" />
+    <!--This is a symbolic link to HKLM\Software\Classes\Wow6432Node.   No need to snap.-->
+    <Exclude path="HKEY_LOCAL_MACHINE\Software\Wow6432Node\Classes" wow64If="false" />
+
+    <!--Only snap the services stuff under HKLM\System-->
+    <Exclude path="HKEY_LOCAL_MACHINE\System\*" />
+    <Include path="HKEY_LOCAL_MACHINE\System\CurrentControlSet" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\*"/>
+    <Include path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\*"/>
+    <Include path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\BackupRestore" /> <!-- This is necessary for Microsoft Outlook -->
+    <Include path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\MSIPC" /> <!-- This is necessary for Microsoft Office 2013+, STD-3565 -->
+    <Include path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\bam" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\BITS" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\ClipSvc" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\DsmSvc" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\EventLog" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\NcbService" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\rdyboost" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\SharedAccess" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\SmsRouter" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\VSS" />
+    <Exclude path="HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\W32Time " />
+
+    <!--Exclude system registry stuff (HKEY_CURRENT_USER)-->
+    <Exclude path="HKEY_CURRENT_USER\*" />
+    <Include path="HKEY_CURRENT_USER\Software" wow64If="false" />
+    
+    <Exclude path="HKEY_CURRENT_USER\Software\Spoon" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Xenocode" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Code Systems" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Policies" />
+    <Include path="HKEY_CURRENT_USER\Software\AppDataLow" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\ActivatableClasses\Package" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\AppID\{7AF9FBAE-1136-40BF-B82F-B443A855DCD2}" /> <!-- turbo plugin -->
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\AppID\Turbo-Plugin*" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\Extensions\ContractId" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\Local Settings" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\PackagedCom\ClassIndex" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\PackagedCom\Package" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\turbo" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\Turbo-Plugin*" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\VirtualStore" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\CLSID\{3D58DDEA-561E-45BA-AA6A-0AB04BCD9FAD}" /> <!-- turbo plugin -->
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\Interface\{7F5F65EA-0802-41CB-AD41-808AF6830CF0}" /> <!-- turbo plugin -->
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\Interface\{BA4C9F7A-59F9-47F9-937B-EABAD0286A45}" /> <!-- turbo plugin -->
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\TypeLib\{8F9A5B9B-1A72-42A1-A633-FD8F8D0CE328}" /> <!-- turbo plugin -->
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\TypeLib\{BBEFC9EE-D449-4CC6-A330-A3138FF89EF3}" /> <!-- turbo plugin -->
+    <Exclude path="HKEY_CURRENT_USER\Software\Classes\WOW6432Node\CLSID\{F44E4433-DDC6-4F0B-AF6F-7E673B349E90}" /> <!-- turbo plugin -->
+    <Exclude path="HKEY_CURRENT_USER\Software\Google\Chrome\NativeMessagingHosts\net.spoon.chromenativehost" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Mozilla\NativeMessagingHosts\net.spoon.chromenativehost" />
+    <Exclude path="HKEY_CURRENT_USER\Software\MozillaPlugins\*Turbo.net*" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\AuthCookies" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Ctf" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Fusion" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Notepad" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Direct3d" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Iam" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\IdentityCRL" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Multimedia" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows Script" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Search Assistant" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\EventSystem" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Cryptography" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\OneDrive" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\PCHealth" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Phone" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Poom" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\RestartManager" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Speech_OneCore" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Unified Store" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ActivityDataModel" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\AppBroadcast" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\AppHost" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Authentication" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\CloudStore" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Cortana" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\GameDVR" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\InstallService" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Lock Screen" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\PushNotifications" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\SettingSync" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Exts\Stats\{3D58DDEA-561E-45BA-AA6A-0AB04BCD9FAD}" /> <!-- turbo plugin -->
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Exts\Stats\{F44E4433-DDC6-4F0B-AF6F-7E673B349E90}" /> <!-- turbo plugin -->
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Security and Maintenance" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Search" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\UFH" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\Shell" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows\Winlogon" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows Media" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows Search" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows Defender" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\HostActivityManager" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\Network\Location Awareness" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\TileDataModel" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\SystemCertificates" />
+    <Exclude path="HKEY_CURRENT_USER\Software\Microsoft\Protected Storage System Provider" />
+    
+    <!-- causes problems with registration on win10 (STD-2906) -->
+    <Exclude path="HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts" />
+
+    <!--Symbolic link to HKEY_CURRENT_USER\Software.  No need to snap.-->
+    <Exclude path="HKEY_CURRENT_USER\Software\Wow6432Node" wow64If="false" />
+
+    <Exclude path="HKEY_USERS\*" />
+    <!--
+    <Include path="HKEY_USERS\.Default" />
+    <Include path="HKEY_USERS\S-1-5-18" />
+    <Include path="HKEY_USERS\S-1-5-19" />
+    -->
+    <Include path="HKEY_USERS\S-1-5-20" />
+    <Exclude path="HKEY_USERS\S-1-5-20\*" />
+    <Include path="HKEY_USERS\S-1-5-20\Software" />
+    <Exclude path="HKEY_USERS\S-1-5-20\Software\*" />
+    <Include path="HKEY_USERS\S-1-5-20\Software\AppDataLow" />
+    <Include path="HKEY_USERS\S-1-5-20\Software\Microsoft" />
+    <Exclude path="HKEY_USERS\S-1-5-20\Software\Microsoft\*" />
+    <Include path="HKEY_USERS\S-1-5-20\Software\Microsoft\OfficeSoftwareProtectionPlatform" />
+
+    <!--AllOrNothing mean that any immediate subkey of the given root is added in 
+        all-or-nothing fashion.  Any add/modify under one of these locations causes the
+        entire sub-tree to be added.  One can also configure names for subkey exceptions.
+        Setting wow64iIf="True" (the default) will cause both flavors of the path to be added, as 
+        in: HKEY_LOCAL_MACHINE\Software\Classes\AppId and
+            HKEY_LOCAL_MACHINE\Software\Classes\Wow6432Node\AppId -->
+            
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes" wow64If="true" >
+      <Exception name="DirectShow" />
+      <Exception name="Media Type" />
+      <Exception name="MediaFoundation" />
+      <Exception name="Installer" />
+      <Exception name="MIME"  />
+      <Exception name="PROTOCOLS" />
+      <Exception name="Applications" />
+      <Exception name="AppID" />
+      <Exception name="FileType" />
+      <Exception name="CLSID" />
+      <Exception name="Component Categories" />
+      <Exception name="Interface" />
+      <Exception name="TypeLib" />
+      <Exception name="SystemFileAssociations" />
+      <Exception name="Record" />
+      <Exception name="Licenses" />
+    </AllOrNothing>
+    
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes" wow64If="true" >
+      <Exception name="DirectShow" />
+      <Exception name="Media Type" />
+      <Exception name="MediaFoundation" />
+      <Exception name="Installer" />
+      <Exception name="MIME"  />
+      <Exception name="PROTOCOLS" />
+      <Exception name="Applications" />
+      <Exception name="AppID" />
+      <Exception name="FileType" />
+      <Exception name="CLSID" />
+      <Exception name="Component Categories" />
+      <Exception name="Interface" />
+      <Exception name="TypeLib" />
+      <Exception name="SystemFileAssociations" />
+      <Exception name="Record" />
+      <Exception name="Licenses" />
+      <Exception name="exefile" />
+      <Exception name="Folder" />
+      <Exception name="Drive" />
+    </AllOrNothing>
+            
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes\Applications" />
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes\Applications" />
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes\AppID" />
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes\AppID" />
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes\FileType" />
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes\FileType" />
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes\CLSID" />
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes\CLSID" />
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes\Component Categories" />
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes\Component Categories" />
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes\Interface" />
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes\Interface" />
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes\TypeLib" />
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes\TypeLib" />
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes\SystemFileAssociations" />
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes\SystemFileAssociations" />
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes\Record" />
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes\Record" />
+    <AllOrNothing path="HKEY_CURRENT_USER\Software\Classes\Licenses" />
+    <AllOrNothing path="HKEY_LOCAL_MACHINE\Software\Classes\Licenses" />
+    
+    <Isolation path="@HKLM@\Software\Classes\Installer" isolation="WriteCopy" />
+    <Isolation path="@HKLM@\Software\Microsoft\Windows\CurrentVersion\Installer\UserData" isolation="WriteCopy" />
+    <Isolation path="@HKLM@\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Installer\UserData" isolation="WriteCopy" />
+
+  </Registry>
+
+</SnapshotSettings>

--- a/microsoft_teams-arm64/VersionCheck.ps1
+++ b/microsoft_teams-arm64/VersionCheck.ps1
@@ -1,0 +1,39 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use this section to get the latest version 
+# either from the vendor website or the downloaded installer file
+
+# Get installer link for latest version
+$DownloadLink = "https://go.microsoft.com/fwlink/?linkid=2196207"
+
+# Name of the downloaded installer file
+$InstallerName = "Teams_windows_arm64.zip"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+# Extract ZIP archive.
+Expand-Archive -Path $DownloadPath\$InstallerName -DestinationPath "$DownloadPath\Extracted"
+
+$LatestWebVersion = Get-VersionFromExe "$DownloadPath\Extracted\ms-teams.exe"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/microsoft_vcredist-arm64/BuildTurboImage.ps1
+++ b/microsoft_vcredist-arm64/BuildTurboImage.ps1
@@ -1,0 +1,123 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Microsoft"
+$AppDesc = "Many applications built using Microsoft C and C++ tools require these libraries."
+$AppName = "Microsoft Visual C++ Redistributable ARM64"
+$VendorURL = "https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+# Get installer for latest version
+Invoke-WebRequest -Uri https://aka.ms/vs/17/release/vc_redist.arm64.exe -OutFile "$DownloadPath\vc_redist.arm64.exe"
+
+$InstalledVersion = Get-VersionFromExe "$DownloadPath\vc_redist.arm64.exe"
+$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Use /norestart - on WoA a silent vc_redist install performs the required restart and reboots the capture VM
+$ProcessExitCode = RunProcess "$DownloadPath\vc_redist.arm64.exe" "/install /quiet /norestart" $True
+# 3010 = ERROR_SUCCESS_REBOOT_REQUIRED: the install succeeded and only a reboot is
+# pending - the ARM64 CRT consistently returns this on a clean image, so treat as success
+if ($ProcessExitCode -eq 3010) { $ProcessExitCode = 0 }
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Get the year version from the Unintall registry key (eg Microsoft Visual C++ 2022 ARM64 Minimum Runtime - 14.38.33135)
+# The arm64 runtime registers in the native hive, not WOW6432Node - check both
+$UninstallPaths = @("HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall", "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall")
+foreach ($subkey in ($UninstallPaths | Where-Object { Test-Path $_ } | Get-ChildItem)) {
+    $name = (Get-ItemProperty $subkey.PSPath).DisplayName
+    if ($name -match "Minimum Runtime") {
+        $RegistryVersion = (Get-ItemProperty $subkey.PSPath).DisplayName
+    }
+}
+
+# Parse out the year from the registry key
+$extractedVersion = $RegistryVersion -replace ".*C\+\+\s(\d{4}).*", '$1'
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+#Publish a second time using the Year version (eg 2022)
+PushImage $extractedVersion
+

--- a/microsoft_vcredist-arm64/BuildTurboImage.ps1
+++ b/microsoft_vcredist-arm64/BuildTurboImage.ps1
@@ -84,15 +84,18 @@ WriteLog "Performing post-install customizations."
 # Get the year version from the Unintall registry key (eg Microsoft Visual C++ 2022 ARM64 Minimum Runtime - 14.38.33135)
 # The arm64 runtime registers in the native hive, not WOW6432Node - check both
 $UninstallPaths = @("HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall", "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall")
-foreach ($subkey in ($UninstallPaths | Where-Object { Test-Path $_ } | Get-ChildItem)) {
-    $name = (Get-ItemProperty $subkey.PSPath).DisplayName
-    if ($name -match "Minimum Runtime") {
-        $RegistryVersion = (Get-ItemProperty $subkey.PSPath).DisplayName
-    }
+$UninstallNames = $UninstallPaths | Where-Object { Test-Path $_ } | Get-ChildItem | ForEach-Object { (Get-ItemProperty $_.PSPath).DisplayName }
+
+$RegistryVersion = $UninstallNames | Where-Object { $_ -match "Minimum Runtime" } | Select-Object -Last 1
+# The arm64 redist registers only the bundle entry (eg Microsoft Visual C++ 2015-2022 Redistributable (Arm64) - 14.44.35211),
+# not the per-MSI "Minimum Runtime" entries the x64 recipe matches on - fall back to the bundle name
+if (-not $RegistryVersion) {
+    $RegistryVersion = $UninstallNames | Where-Object { $_ -match "Visual C\+\+.*Redistributable" } | Select-Object -Last 1
 }
 
-# Parse out the year from the registry key
-$extractedVersion = $RegistryVersion -replace ".*C\+\+\s(\d{4}).*", '$1'
+# Parse out the year from the registry key - take the last year so "2015-2022" yields 2022.
+# Lookarounds require exactly 4 digits, so version numbers like 35211 never match.
+$extractedVersion = ([regex]::Matches("$RegistryVersion", '(?<!\d)\d{4}(?!\d)') | Select-Object -Last 1).Value
 
 
 #########################
@@ -119,5 +122,11 @@ BuildTurboSvmImage
 
 PushImage $InstalledVersion
 #Publish a second time using the Year version (eg 2022)
-PushImage $extractedVersion
+# Guarded - a failed parse must skip this push, not publish an empty tag
+if ($extractedVersion -match '^\d{4}$') {
+    PushImage $extractedVersion
+}
+else {
+    WriteLog "Could not determine year version from uninstall entries - skipping the year-tagged push."
+}
 

--- a/microsoft_vcredist-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/microsoft_vcredist-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,3 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+

--- a/microsoft_vcredist-arm64/VersionCheck.ps1
+++ b/microsoft_vcredist-arm64/VersionCheck.ps1
@@ -1,0 +1,32 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+$HubVersion = $HubVersion.Split(" ")[-1]
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use this section to get the latest version 
+# either from the vendor website or the downloaded installer file
+
+# Get installer link for latest version
+Invoke-WebRequest -Uri https://aka.ms/vs/17/release/vc_redist.arm64.exe -OutFile "$DownloadPath\vc_redist.arm64.exe"
+
+$LatestWebVersion = Get-VersionFromExe "$DownloadPath\vc_redist.arm64.exe"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/mozilla_firefox-esr-arm64/BuildTurboImage.ps1
+++ b/mozilla_firefox-esr-arm64/BuildTurboImage.ps1
@@ -1,0 +1,130 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Mozilla"
+$AppDesc = "Mozillas popular open source browser enhanced for performance, privacy, and functionality."
+$AppName = "Firefox ESR ARM64"
+$VendorURL = "https://www.mozilla.org/en-US/firefox/new/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Get installer link for latest version
+# Mozilla ships no MSI for ARM64 - use the exe installer like the commercial firefox-arm64 recipe
+$DownloadLink = "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64-aarch64&lang=en-US"
+
+# Name of the downloaded installer file
+$InstallerName = "FirefoxSetup.exe"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Install the application (exe installer - same silent switches as the commercial firefox-arm64 recipe)
+$ProcessExitCode = RunProcess $Installer "-ms /MaintenanceService=false /TaskbarShortcut=false /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+# Create ProgIDs for http and https
+$ProcessExitCode = RunProcess "C:\Program Files\Mozilla Firefox\uninstall\helper.exe" "/SetAsDefaultAppUser" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $False # Proceed on install error
+$ProcessExitCode = RunProcess "C:\Program Files\Mozilla Firefox\uninstall\helper.exe" "/SetAsDefaultAppGlobal" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $False # Proceed on install error
+
+# Copy policies.json - to C:\Program Files\Mozilla Firefox\distribution
+Copy-Item "$SupportFiles\distribution" -Destination "C:\Program Files\Mozilla Firefox\"  -Recurse -Force
+# Copy mozilla.cfg - to C:\Program Files\Mozilla Firefox
+Copy-Item "$SupportFiles\mozilla.cfg" -Destination "C:\Program Files\Mozilla Firefox\"  -Recurse -Force
+# Copy local-settings.js - to C:\Program Files\Mozilla Firefox\defaults\pref
+Copy-Item "$SupportFiles\defaults" -Destination "C:\Program Files\Mozilla Firefox\"  -Recurse -Force
+
+# Delete all values under HKCU\SOFTWARE\Mozilla\Firefox\Launcher
+&reg.exe delete "HKCU\SOFTWARE\Mozilla\Firefox\Launcher" /va /f
+# Add back the Browser key.  This resolves an issue launching web pages.
+&reg.exe add "HKCU\SOFTWARE\Mozilla\Firefox\Launcher" /t REG_QWORD /d 0 /v "C:\Program Files\Mozilla Firefox\firefox.exe|Browser" /f
+
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+
+$InstalledVersion = GetVersionFromRegistry "Firefox"
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/mozilla_firefox-esr-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/mozilla_firefox-esr-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,36 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+# Configure vm settings
+$VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
+$VirtualizationSettings.chromiumSupport = [string]$true
+
+
+#################
+# Edit Registry #
+#################
+## NOTE: Beware of case sensitivity when making registry changes.  eg. The registry value type "String" requires an upper-case 'S'
+##       When specifying a registry value, "OpenWithProgids" is different from "OpenWithProgIds"
+
+
+# Set Full isolation on HKCU\SOFTWARE\Mozilla\Firefox\Launcher - This fixes an issue loading web pages if Firefox is installed natively
+# Null-guarded: arm64 captures don't always produce the same registry tree as x64
+$LauncherKey = $Registry.SelectSingleNode("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Mozilla']/Key[@name='Firefox']/Key[@name='Launcher']")
+if ($LauncherKey) { $LauncherKey.isolation = "Full" }
+
+
+#################
+# Other Changes #
+#################
+
+# Clone the OPEN verb to TURBOCLIENT_v24.2_LEGACY_PROGID for http and https ProgIDs
+# Null-guarded: skip any ProgId/verb the arm64 capture did not register
+foreach ($progIdName in @('http', 'https')) {
+    $ProgIDNode = $xappl.SelectSingleNode("//ProgId[@name='$progIdName']")
+    $openVerbNode = if ($ProgIDNode) { $ProgIDNode.SelectSingleNode(".//Verb[@name='open']") } else { $null }
+    if ($openVerbNode) {
+        $newVerbNode = $openVerbNode.Clone()
+        $newVerbNode.SetAttribute("name", "TURBOCLIENT_v24.2_LEGACY_PROGID")
+        $ProgIDNode.AppendChild($newVerbNode)
+    }
+}

--- a/mozilla_firefox-esr-arm64/SupportFiles/defaults/pref/local-settings.js
+++ b/mozilla_firefox-esr-arm64/SupportFiles/defaults/pref/local-settings.js
@@ -1,0 +1,3 @@
+// This file tells Firefox to use the mozilla.cfg preferences file
+pref("general.config.filename", "mozilla.cfg");
+pref("general.config.obscure_value", 0);

--- a/mozilla_firefox-esr-arm64/SupportFiles/distribution/policies.json
+++ b/mozilla_firefox-esr-arm64/SupportFiles/distribution/policies.json
@@ -1,0 +1,11 @@
+{
+  "policies": {
+    "DisableAppUpdate": true,
+    "DisableProfileRefresh": true,
+    "DisableTelemetry": true,
+    "DisableFirefoxStudies": true,
+    "DontCheckDefaultBrowser": true,
+    "OverrideFirstRunPage": "",
+    "OverridePostUpdatePage": ""
+  }
+}

--- a/mozilla_firefox-esr-arm64/SupportFiles/mozilla.cfg
+++ b/mozilla_firefox-esr-arm64/SupportFiles/mozilla.cfg
@@ -1,0 +1,3 @@
+// Use this file to set pref, defaultPref and lockPref settings
+pref("termsofuse.bypassNotification", true); // prevents first launch terms of use prompt
+pref("browser.startup.couldRestoreSession.count", 2); // prevents tab restore infobar on second launch

--- a/mozilla_firefox-esr-arm64/VersionCheck.ps1
+++ b/mozilla_firefox-esr-arm64/VersionCheck.ps1
@@ -1,0 +1,32 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use this section to get the latest version 
+# either from the vendor website or the downloaded installer file
+
+# Get latest version from release notes page
+$Page = curl 'https://product-details.mozilla.org/1.0/firefox_versions.json' -UseBasicParsing
+$jsonData = $Page.Content | ConvertFrom-Json
+$LatestWebVersion = $jsonData.FIREFOX_ESR
+$LatestWebVersion = $LatestWebVersion.Replace("esr", "")
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/paintdotnet_paintdotnet-arm64/BuildTurboImage.ps1
+++ b/paintdotnet_paintdotnet-arm64/BuildTurboImage.ps1
@@ -1,0 +1,120 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "dotPDN LLC"
+$AppDesc = "Paint.NET is image and photo editing software for PCs that run Windows."
+$AppName = "Paint.NET ARM64"
+$VendorURL = "https://www.getpaint.net/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Get main download page for application.
+$Page = curl https://github.com/paintdotnet/release/releases/latest -UseBasicParsing
+
+# Get the latest tag (used to build download link) and installed version (used to build download link and svm image meta).
+$VersionTag = (($Page.Links | Where-Object {$_.href -like "*/releases/tag*"}).href).split("/")[-1]
+$InstalledVersion = $VersionTag.Substring(1)
+
+# Get installer link for latest version.
+$DownloadLink = "https://github.com/paintdotnet/release/releases/download/" + $VersionTag + "/paint.net." + $InstalledVersion + ".winmsi.arm64.zip"
+
+# Name of the downloaded installer file
+$InstallerName = [System.IO.Path]::GetFileName($DownloadLink)
+
+$Installer = wget $DownloadLink -O $DownloadPath\$InstallerName
+
+# Extract ZIP archive.
+Expand-Archive -Path $DownloadPath\$InstallerName -DestinationPath $DownloadPath
+
+# Update InstallerName to extracted MSI.
+$InstallerName = $installername.substring(0,$installername.length-3) + "msi"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess "msiexec.exe" "/I $DownloadPath\$InstallerName ALLUSERS=1 /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+$InstalledVersion = GetVersionFromRegistry "Paint.NET"
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/paintdotnet_paintdotnet-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/paintdotnet_paintdotnet-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,43 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+###################
+# Edit Filesystem #
+###################
+
+## Add Current User Directory\Local Application Data\paint.net directory
+$node = $xappl.CreateElement("Directory")
+$node.SetAttribute("name","paint.net")
+$node.SetAttribute("isolation","Full")
+$node.SetAttribute("readOnly","False")
+$node.SetAttribute("hide","False")
+$node.SetAttribute("noSync","True")
+$Filesystem.SelectNodes("Directory[@name='@APPDATALOCAL@']").AppendChild($node)
+
+
+#################
+# Edit Registry #
+#################
+## NOTE: Beware of case sensitivity when making registry changes.  eg. The registry value type "String" requires an upper-case 'S'
+##       When specifying a registry value, "OpenWithProgids" is different from "OpenWithProgIds"
+
+## Add HKCU\SOFTWARE\paint.net registry key
+$node = $xappl.CreateElement("Key")
+$node.SetAttribute("name","paint.net")
+$node.SetAttribute("isolation","Full")
+$node.SetAttribute("readOnly","False")
+$node.SetAttribute("hide","False")
+$node.SetAttribute("noSync","False")
+$Registry.SelectNodes("Key[@name='@HKCU@']/Key[@name='Software']").AppendChild($node)
+
+## Set HKLM\SOFTWARE\paint.net registry key and its children to full isolation
+## Null-guarded: arm64 captures don't always produce the same registry tree as x64
+$paintKeys = @(
+    "Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='paint.net']",
+    "Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='paint.net']/Key[@name='Capabilities']",
+    "Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='paint.net']/Key[@name='Capabilities']/Key[@name='FileAssociations']"
+)
+foreach ($keyPath in $paintKeys) {
+    $keyNode = $Registry.SelectSingleNode($keyPath)
+    if ($keyNode) { $keyNode.isolation = "Full" }
+}

--- a/paintdotnet_paintdotnet-arm64/VersionCheck.ps1
+++ b/paintdotnet_paintdotnet-arm64/VersionCheck.ps1
@@ -1,0 +1,34 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use this section to get the latest version 
+# either from the vendor website or the downloaded installer file
+
+# Get main download page for application.
+$Page = curl https://github.com/paintdotnet/release/releases/latest -UseBasicParsing
+
+# Get the latest tag (used to build download link) and installed version (used to build download link and svm image meta).
+$VersionTag = (($Page.Links | Where-Object {$_.href -like "*/releases/tag*"}).href).split("/")[-1]
+$LatestWebVersion = $VersionTag.Substring(1)
+
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/postman_postman-arm64/BuildTurboImage.ps1
+++ b/postman_postman-arm64/BuildTurboImage.ps1
@@ -1,0 +1,115 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Postman"
+$AppDesc = "Create and execute any REST, SOAP, and GraphQL queries from within Postman."
+$AppName = "Postman API Client ARM64"
+$VendorURL = "https://www.postman.com/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$DownloadLink = "https://dl.pstmn.io/download/latest/win_arm64"
+$InstallerName = "Postman-win_arm64-Setup.exe"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$InstalledVersion = Get-VersionFromExe $Installer
+$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Install Applicaton
+$ProcessExitCode = RunProcess $Installer "" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+# Wait for the shortcut to get created
+$shortcut = "$env:USERPROFILE\Desktop\Postman.lnk"
+Wait-ForFileExistence $shortcut -Iterations 300 -SleepTime 1  # Exit if file doesn't exist after 5 minutes
+
+# Wait for the Update.exe process to finish
+CheckRunningProcess "Update.exe"
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Close the application to release any locked files
+taskkill.exe /f /im postman.exe /t
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/postman_postman-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/postman_postman-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,13 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+# Configure vm settings
+$VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
+$VirtualizationSettings.chromiumSupport = [string]$true
+
+# Edit ObjectMaps - Add ObjectMap node to add a network ip restriction deny action to dl.pstmn.io
+# Preventing network access to ip://dl.pstmn.io will prevent the application from checking for updates
+$ObjectMaps = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("ObjectMaps")
+$node = $xappl.CreateElement("ObjectMap")
+$node.SetAttribute("value","ip://dl.pstmn.io@0.0.0.0")
+$ObjectMaps.AppendChild($node)

--- a/postman_postman-arm64/VersionCheck.ps1
+++ b/postman_postman-arm64/VersionCheck.ps1
@@ -1,0 +1,33 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use this section to get the latest version 
+# either from the vendor website or the downloaded installer file
+
+$DownloadLink = "https://dl.pstmn.io/download/latest/win_arm64"
+$InstallerName = "Postman-win_arm64-Setup.exe"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = Get-VersionFromExe $Installer
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/putty_putty-arm64/BuildTurboImage.ps1
+++ b/putty_putty-arm64/BuildTurboImage.ps1
@@ -1,0 +1,111 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Putty"
+$AppDesc = "PuTTY is an SSH and telnet client. PuTTY is open source software that is available with source code."
+$AppName = "Putty ARM64"
+$VendorURL = "https://www.putty.org/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$Page = curl 'https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html' -UseBasicParsing
+
+# Get installer link for latest version (wa64 = Windows on Arm 64-bit; *arm64* excludes the arm32 installer)
+$DownloadLink = ($Page.Links | Where-Object {$_.href -like "*arm64*.msi"})[0].href
+
+$InstallerName = $DownloadLink.Split("/")[-1]
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$InstalledVersion = $InstallerName.Split("-")[-2]
+$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Install GoTo Connect for all users with updates disabled
+$ProcessExitCode = RunProcess "msiexec.exe" "/I $Installer INSTALLDIR=`"C:\PuTTY`" ALLUSERS=1 /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion

--- a/putty_putty-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/putty_putty-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,15 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+######################
+# Edit Startup Files #
+######################
+## Change the container startup file to putty.exe
+## Null-guarded: arm64 captures don't always auto-register the same StartupFiles as x64
+$StartupFiles = $xappl.Configuration.SelectSingleNode("StartupFiles")
+$pageantNode = $StartupFiles.SelectSingleNode("StartupFile[@node='@SYSDRIVE@\PuTTY\pageant.exe']")
+if ($pageantNode) { $pageantNode.default = 'False' }
+$parentNode = $StartupFiles.SelectNodes("StartupFile[@node='@SYSDRIVE@\PuTTY\putty.exe']")
+ForEach ($childNodes in $parentNode) {
+    $childNodes.SetAttribute("default", "True")
+}

--- a/putty_putty-arm64/VersionCheck.ps1
+++ b/putty_putty-arm64/VersionCheck.ps1
@@ -1,0 +1,32 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$Page = curl 'https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html' -UseBasicParsing
+
+# Get installer link for latest version (wa64 = Windows on Arm 64-bit; *arm64* excludes the arm32 installer)
+$DownloadLink = ($Page.Links | Where-Object {$_.href -like "*arm64*.msi"})[0].href
+
+$InstallerName = $DownloadLink.Split("/")[-1]
+
+$LatestWebVersion = $InstallerName.Split("-")[-2]
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/sqlserver_ssms-arm64/BuildTurboImage.ps1
+++ b/sqlserver_ssms-arm64/BuildTurboImage.ps1
@@ -1,0 +1,116 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Microsoft"
+$AppDesc = "SSMS is an integrated environment for configuring, managing, and developing for SQL Server."
+$AppName = "SQL Server Management Studio ARM64"
+$VendorURL = "https://learn.microsoft.com/en-us/sql/ssms/sql-server-management-studio-ssms?view=sql-server-ver16"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+# Get installer link for latest version
+# Native ARM64 requires SSMS 22+, which uses the VS-installer-based vs_SSMS.exe bootstrapper
+# (the x64 aka.ms/ssmsfullsetup serves the older Wix-based 20.x installer with no arm64 build)
+$DownloadLink = "https://aka.ms/ssms/22/release/vs_SSMS.exe"
+
+# Name of the downloaded installer file
+$InstallerName = "vs_SSMS.exe"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# VS-installer bootstrapper silent install; --wait keeps the bootstrapper alive until setup finishes
+$ProcessExitCode = RunProcess "$Installer" "--quiet --norestart --wait" $True
+# 3010 = ERROR_SUCCESS_REBOOT_REQUIRED: install succeeded, only a reboot is pending - treat as success
+if ($ProcessExitCode -eq 3010) { $ProcessExitCode = 0 }
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+$InstalledVersion = GetVersionFromRegistry "SQL Server Management Studio"
+
+# Disable Update Checker - since this key will likely change with the version we need to get the major version first
+$majorVersion = ($InstalledVersion -split '\.')[0]
+&reg add "HKEY_CURRENT_USER\Software\Microsoft\SQL Server Management Studio\$majorVersion.0_IsoShell\UpdateChecker" /v "Enabled" /t REG_SZ /d "False" /f
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/sqlserver_ssms-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/sqlserver_ssms-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -10,27 +10,19 @@ $virtualizationSettings.launchChildProcsAsUser = [string]$true
 ######################
 # Edit Startup Files #
 ######################
-# Get the path to the Ssms.exe file
-# SSMS 22 (arm64) installs under Program Files, not Program Files (x86) like 20.x - check both
-$ssmsDir = Get-ChildItem -Path "C:\Program Files" -Recurse -Filter "Ssms.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
-if ($ssmsDir) {
-    $installDir = $ssmsDir.Directory.FullName
-    $installDir = $installDir -replace [regex]::Escape($env:ProgramFiles), "@PROGRAMFILES@"
-} else {
-    $ssmsDir = Get-ChildItem -Path "C:\Program Files (x86)" -Recurse -Filter "Ssms.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
-    $installDir = $ssmsDir.Directory.FullName
-    $installDir = $installDir -replace [regex]::Escape("${env:ProgramFiles(x86)}"), "@PROGRAMFILESX86@"
-}
-$installDir
-
 ## Change the container startup file to SSMS.exe
-## Null-guarded: arm64 captures don't always auto-register the same StartupFiles as x64
+## The SSMS 22 capture also brings in the Visual Studio Installer, whose exe gets
+## auto-registered as a default startup file and would launch instead of SSMS.
+## Disable every startup file, then enable only Ssms.exe (matched by filename -
+## the VS-installer-based layout makes the full path unreliable).
 $StartupFiles = $xappl.Configuration.SelectSingleNode("StartupFiles")
-$deployNode = $StartupFiles.SelectSingleNode("StartupFile[@node='$installDir\Microsoft.AnalysisServices.Deployment.exe']")
-if ($deployNode) { $deployNode.default = 'False' }
-$parentNode = $StartupFiles.SelectNodes("StartupFile[@node='$installDir\Ssms.exe']")
-ForEach ($childNodes in $parentNode) {
-    $childNodes.SetAttribute("default", "True")
+foreach ($sf in $StartupFiles.SelectNodes("StartupFile")) {
+    if ($sf.node -like '*\Ssms.exe') {
+        $sf.SetAttribute("default", "True")
+    }
+    else {
+        $sf.SetAttribute("default", "False")
+    }
 }
 
 #################

--- a/sqlserver_ssms-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/sqlserver_ssms-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,63 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+# Configure vm settings
+$VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
+$virtualizationSettings.isolateWindowClasses = [string]$true
+$virtualizationSettings.launchChildProcsAsUser = [string]$true
+
+
+######################
+# Edit Startup Files #
+######################
+# Get the path to the Ssms.exe file
+# SSMS 22 (arm64) installs under Program Files, not Program Files (x86) like 20.x - check both
+$ssmsDir = Get-ChildItem -Path "C:\Program Files" -Recurse -Filter "Ssms.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($ssmsDir) {
+    $installDir = $ssmsDir.Directory.FullName
+    $installDir = $installDir -replace [regex]::Escape($env:ProgramFiles), "@PROGRAMFILES@"
+} else {
+    $ssmsDir = Get-ChildItem -Path "C:\Program Files (x86)" -Recurse -Filter "Ssms.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+    $installDir = $ssmsDir.Directory.FullName
+    $installDir = $installDir -replace [regex]::Escape("${env:ProgramFiles(x86)}"), "@PROGRAMFILESX86@"
+}
+$installDir
+
+## Change the container startup file to SSMS.exe
+## Null-guarded: arm64 captures don't always auto-register the same StartupFiles as x64
+$StartupFiles = $xappl.Configuration.SelectSingleNode("StartupFiles")
+$deployNode = $StartupFiles.SelectSingleNode("StartupFile[@node='$installDir\Microsoft.AnalysisServices.Deployment.exe']")
+if ($deployNode) { $deployNode.default = 'False' }
+$parentNode = $StartupFiles.SelectNodes("StartupFile[@node='$installDir\Ssms.exe']")
+ForEach ($childNodes in $parentNode) {
+    $childNodes.SetAttribute("default", "True")
+}
+
+#################
+# Edit Registry #
+#################
+## NOTE: Beware of case sensitivity when making registry changes.  eg. The registry value type "String" requires an upper-case 'S'
+##       When specifying a registry value, "OpenWithProgids" is different from "OpenWithProgIds"
+
+# Set WriteCopy isolation on @HKCU@\SOFTWARE\Microsoft\SQL Server Management Studio and subkeys
+$parentNode = $Registry.SelectNodes("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Microsoft']/Key[@name='SQL Server Management Studio']/descendant-or-self::*")
+ForEach ($childNodes in $parentNode) {
+    $childNodes.SetAttribute("isolation", "WriteCopy")
+}
+# Set WriteCopy isolation on @HKCU@\SOFTWARE\Microsoft\VisualStudio and subkeys
+$parentNode = $Registry.SelectNodes("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Microsoft']/Key[@name='VisualStudio']/descendant-or-self::*")
+ForEach ($childNodes in $parentNode) {
+    $childNodes.SetAttribute("isolation", "WriteCopy")
+}
+# Set WriteCopy isolation on @HKCU@\SOFTWARE\Microsoft\VSCommon and subkeys
+$parentNode = $Registry.SelectNodes("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Microsoft']/Key[@name='VSCommon']/descendant-or-self::*")
+ForEach ($childNodes in $parentNode) {
+    $childNodes.SetAttribute("isolation", "WriteCopy")
+}
+
+#################
+# Edit Files    #
+#################
+# Change folder and subfolders from Merge to WriteCopy isolation
+PushFolderIsolation "Directory[@name='@APPDATALOCAL@']/descendant-or-self::*" "Merge" "WriteCopy"
+PushFolderIsolation "Directory[@name='@APPDATA@']/descendant-or-self::*" "Merge" "WriteCopy"

--- a/sqlserver_ssms-arm64/VersionCheck.ps1
+++ b/sqlserver_ssms-arm64/VersionCheck.ps1
@@ -1,0 +1,36 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use this section to get the latest version 
+# either from the vendor website or the downloaded installer file
+
+# Get installer link for latest version (SSMS 22 bootstrapper; its ProductVersion tracks the SSMS release, eg 22.8.2)
+$DownloadLink = "https://aka.ms/ssms/22/release/vs_SSMS.exe"
+
+# Name of the downloaded installer file
+$InstallerName = "vs_SSMS.exe"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = Get-VersionFromExe "$Installer"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/tdf_libreoffice-arm64/BuildTurboImage.ps1
+++ b/tdf_libreoffice-arm64/BuildTurboImage.ps1
@@ -1,0 +1,129 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "The Document Foundation"
+$AppDesc = "LibreOffice is a private, free and open source office suite - the successor project to OpenOffice."
+$AppName = "Libre Office ARM64"
+$VendorURL = "https://www.libreoffice.org/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+    
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$Page = curl 'https://download.documentfoundation.org/libreoffice/stable/' -UseBasicParsing
+
+$versionRegex = [regex]'\d+\.\d+\.\d+'
+$versionMatches = $versionRegex.Matches($Page.Content)
+
+# Get the last version from the matches
+$InstalledVersion = $versionMatches[$versionMatches.Count - 1].Value
+
+$InstallerName = 'LibreOffice_' + $InstalledVersion + '_Win_aarch64.msi'
+$DownloadLink = "https://download.documentfoundation.org/libreoffice/stable/$InstalledVersion/win/aarch64/$InstallerName"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+WriteLog "Downloading the VCRedist installer."
+# Donwload the VC++2015-2022 ARM64 Redistributable
+Invoke-WebRequest -Uri https://aka.ms/vs/17/release/vc_redist.arm64.exe -OutFile "$DownloadPath\vc_redist.arm64.exe"
+
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+# Install the VCRedist ARM64
+# Use /norestart - on WoA a silent vc_redist install performs the required restart and reboots the capture VM
+$ProcessExitCode = RunProcess "$DownloadPath\vc_redist.arm64.exe" "/install /quiet /norestart" $True
+# 3010 = ERROR_SUCCESS_REBOOT_REQUIRED: install succeeded, only a reboot is pending - treat as success
+if ($ProcessExitCode -eq 3010) { $ProcessExitCode = 0 }
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+#ADDLOCAL=ALL: This parameter instructs the MSI to install all LibreOffice features.
+#CREATEDESKTOPLINK=0: When set to "0" no desktop icon is created, if you do want a desktop icon on your user’s computer change this to 1. 
+#REGISTER_ALL_MSO_TYPES=1: Registers all Office types (Writer, Calc, Impress, etc.)
+#REMOVE=gm_o_Onlineupdate: Adding this disables alerts from LibreOffice that your users would otherwise see asking them to update.
+$ProcessExitCode = RunProcess "$DownloadPath\$InstallerName" "ADDLOCAL=ALL CREATEDESKTOPLINK=0 REGISTER_ALL_MSO_TYPES=1 ISCHECKFORPRODUCTUPDATES=0 REMOVE=gm_o_Onlineupdate /qb REBOOT=ReallySuppress" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Copy the "LibreOffice" folder to the users AppData folder - the registrymodifications.xcu file in here will disable Auto Update
+Copy-Item -Path "$SupportFiles\LibreOffice" -Destination "$env:APPDATA\" -Recurse -Force
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/tdf_libreoffice-arm64/SupportFiles/LibreOffice/4/user/registrymodifications.xcu
+++ b/tdf_libreoffice-arm64/SupportFiles/LibreOffice/4/user/registrymodifications.xcu
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oor:items xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<item oor:path="/org.openoffice.Office.Update/Update"><prop oor:name="Enabled" oor:op="fuse"><value>false</value></prop></item>
+</oor:items>

--- a/tdf_libreoffice-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/tdf_libreoffice-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,12 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+
+## Change the container startup file from soffice tag to soffice2 tag (the one without the --safe-mode parameter
+## Null-guarded: arm64 captures don't always auto-register the same StartupFiles as x64
+$StartupFiles = $xappl.Configuration.SelectSingleNode("StartupFiles")
+$sofficeNode = $StartupFiles.SelectSingleNode("StartupFile[@tag='soffice']")
+if ($sofficeNode) { $sofficeNode.default = 'False' }
+
+$soffice2Node = $StartupFiles.SelectSingleNode("StartupFile[@tag='soffice2']")
+if ($soffice2Node) { $soffice2Node.SetAttribute("default", "True") }

--- a/tdf_libreoffice-arm64/VersionCheck.ps1
+++ b/tdf_libreoffice-arm64/VersionCheck.ps1
@@ -1,0 +1,30 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+$Page = curl 'https://download.documentfoundation.org/libreoffice/stable/' -UseBasicParsing
+
+$versionRegex = [regex]'\d+\.\d+\.\d+'
+$versionMatches = $versionRegex.Matches($Page.Content)
+
+# Get the last version from the matches
+$LatestWebVersion = $versionMatches[$versionMatches.Count - 1].Value
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/videolan_vlc-arm64/BuildTurboImage.ps1
+++ b/videolan_vlc-arm64/BuildTurboImage.ps1
@@ -1,0 +1,134 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Videolan"
+$AppDesc = "An open source multimedia framework, player, and server."
+$AppName = "VLC ARM64"
+$VendorURL = "www.videolan.org/vlc/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest installer."
+
+$Page = curl 'https://www.videolan.org/vlc/' -UseBasicParsing
+
+# Get installer link for latest version
+$LatestInstaller = ($Page.Links | Where-Object {$_.href -like "*win64*"})[0].href
+$InstallerName = $LatestInstaller.Split("/")[-1]
+$InstallerVersion = $InstallerName.Split("-")[1]
+
+# Name of the downloaded installer file
+# Use download.videolan.org directly - mirrors are not guaranteed to carry the newer winarm64 builds
+$DownloadLink = "https://download.videolan.org/pub/videolan/vlc/" + $InstallerVersion + "/winarm64/vlc-" + $InstallerVersion +"-winarm64.exe"
+$InstallerName = $DownloadLink.Split("/")[-1]
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess "$Installer" "/L=1033 /S" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Delete web shortcuts from the start menu
+&cmd /c del "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\VideoLAN\VLC\Documentation.lnk"
+&cmd /c del "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\VideoLAN\VLC\VideoLAN website.lnk"
+&cmd /c del "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\VideoLAN\VLC\Release Notes.lnk"
+
+# Launch VLC then send keys to disable Update check and send usage information
+&"C:\Program Files\VideoLAN\VLC\vlc.exe"
+Start-Sleep -Seconds 5
+$wshell = New-Object -ComObject wscript.shell;
+$wshell.AppActivate('Privacy and Network Access Policy')
+Start-Sleep -Seconds 1
+$wshell.SendKeys('{TAB}')
+$wshell.SendKeys(' ')
+$wshell.SendKeys('{TAB}')
+$wshell.SendKeys(' ')
+$wshell.SendKeys('{TAB}')
+$wshell.SendKeys(' ')
+
+# Kill the vlc.exe process
+&cmd.exe /c taskkill /F /IM vlc.exe /T
+
+$InstalledVersion = GetVersionFromRegistry "VLC"
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/videolan_vlc-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/videolan_vlc-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,21 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+######################
+# Edit Startup Files #
+######################
+# add arguments to the startup file to disable update check and send usage information
+# Null-guarded: arm64 captures don't always produce the same StartupFiles/Shortcuts trees as x64
+$StartupFiles = $xappl.Configuration.SelectSingleNode("StartupFiles")
+$vlcStartup = $StartupFiles.SelectSingleNode("StartupFile[@tag='vlc']")
+if ($vlcStartup) { $vlcStartup.commandLine = '--no-qt-privacy-ask --no-qt-updates-notif' }
+
+######################
+# Edit Shortcuts #
+######################
+# add arguments to the shortcuts to disable update check and send usage information
+$Shortcuts = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("Shortcuts")
+$desktopShortcut = $Shortcuts.SelectSingleNode("Folder[@name='Desktop']/Shortcut[@name='VLC media player']")
+if ($desktopShortcut) { $desktopShortcut.arguments = '--no-qt-privacy-ask --no-qt-updates-notif' }
+$programsShortcut = $Shortcuts.SelectSingleNode("Folder[@name='Programs Menu']/Folder[@name='VideoLAN']/Folder[@name='VLC']/Shortcut[@name='VLC media player']")
+if ($programsShortcut) { $programsShortcut.arguments = '--no-qt-privacy-ask --no-qt-updates-notif' }

--- a/videolan_vlc-arm64/VersionCheck.ps1
+++ b/videolan_vlc-arm64/VersionCheck.ps1
@@ -1,0 +1,32 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Get installer link for latest version
+$Page = curl 'https://www.videolan.org/vlc/' -UseBasicParsing
+
+# Get installer link for latest version
+$LatestInstaller = ($Page.Links | Where-Object {$_.href -like "*win64*"})[0].href
+$InstallerName = $LatestInstaller.Split("/")[-1]
+$LatestWebVersion = $InstallerName.Split("-")[1]
+
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/webex_webex-arm64/BuildTurboImage.ps1
+++ b/webex_webex-arm64/BuildTurboImage.ps1
@@ -1,0 +1,116 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Cisco Systems"
+$AppDesc = "Webex is your one place to call, message, meet."
+$AppName = "Webex ARM64"
+$VendorURL = "https://www.webex.com/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Get installer link for latest version
+$DownloadLink = "https://binaries.webex.com/WebexOfclDesktop-Win-Arm-64-Gold/Webex_en.msi"
+
+# Name of the downloaded installer file
+$InstallerName = "Webex_en.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess "msiexec.exe" "/I $Installer ALLUSERS=1 AUTOUPGRADEENABLED=0 ENABLEVDI=2 /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Launch Webex then send the Enter key to accept the agreement
+$ProcessExitCode = RunProcess "C:\Program Files\Cisco Spark\CiscoCollabHost.exe" $False
+Start-Sleep -Seconds 5
+$wshell = New-Object -ComObject wscript.shell;
+$wshell.AppActivate('Webex End User License Agreement')
+Start-Sleep -Seconds 1
+$wshell.SendKeys('{ENTER}')
+
+$InstalledVersion = GetVersionFromRegistry "Webex"
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/webex_webex-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/webex_webex-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,15 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+#################
+# Edit Registry #
+#################
+## NOTE: Beware of case sensitivity when making registry changes.  eg. The registry value type "String" requires an upper-case 'S'
+##       When specifying a registry value, "OpenWithProgids" is different from "OpenWithProgIds"
+
+
+
+# Remove the reg key HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate if captured to prevent discrepancies with the version of WebView2 between the capture device and client device.
+# On arm64, Edge/WebView2 are native so EdgeUpdate can land in the native hive instead of WOW6432Node - remove both.
+$Registry.SelectNodes("Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='WOW6432Node']/Key[@name='Microsoft']/Key[@name='EdgeUpdate']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+$Registry.SelectNodes("Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='Microsoft']/Key[@name='EdgeUpdate']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }

--- a/webex_webex-arm64/VersionCheck.ps1
+++ b/webex_webex-arm64/VersionCheck.ps1
@@ -1,0 +1,36 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use this section to get the latest version 
+# either from the vendor website or the downloaded installer file
+
+# Get installer link for latest version
+$DownloadLink = "https://binaries.webex.com/WebexOfclDesktop-Win-Arm-64-Gold/Webex_en.msi"
+
+# Name of the downloaded installer file
+$InstallerName = "Webex_en.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = Get-MsiProductVersion "$Installer"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/webex_webex-fedramp-arm64/BuildTurboImage.ps1
+++ b/webex_webex-fedramp-arm64/BuildTurboImage.ps1
@@ -1,0 +1,116 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Cisco Systems"
+$AppDesc = "Webex is your one place to call, message, meet."
+$AppName = "Webex for Government ARM64"
+$VendorURL = "https://www.webex.com/industries/government-fedramp.html"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Get installer link for latest version
+$DownloadLink = "https://binaries.webex.com/WebexOfclDesktop-Win-Arm-64-Gold/Webex_en.msi"
+
+# Name of the downloaded installer file
+$InstallerName = "Webex_en.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess "msiexec.exe" "/I $Installer FEDRAMPENABLED=1 ALLUSERS=1 AUTOUPGRADEENABLED=0 ENABLEVDI=2 /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+# Launch Webex then send the Enter key to accept the agreement
+$ProcessExitCode = RunProcess "C:\Program Files\Cisco Spark\CiscoCollabHost.exe" $False
+Start-Sleep -Seconds 5
+$wshell = New-Object -ComObject wscript.shell;
+$wshell.AppActivate('Webex End User License Agreement')
+Start-Sleep -Seconds 1
+$wshell.SendKeys('{ENTER}')
+
+$InstalledVersion = GetVersionFromRegistry "Webex"
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/webex_webex-fedramp-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/webex_webex-fedramp-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,15 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+#################
+# Edit Registry #
+#################
+## NOTE: Beware of case sensitivity when making registry changes.  eg. The registry value type "String" requires an upper-case 'S'
+##       When specifying a registry value, "OpenWithProgids" is different from "OpenWithProgIds"
+
+
+
+# Remove the reg key HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate if captured to prevent discrepancies with the version of WebView2 between the capture device and client device.
+# On arm64, Edge/WebView2 are native so EdgeUpdate can land in the native hive instead of WOW6432Node - remove both.
+$Registry.SelectNodes("Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='WOW6432Node']/Key[@name='Microsoft']/Key[@name='EdgeUpdate']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }
+$Registry.SelectNodes("Key[@name='@HKLM@']/Key[@name='SOFTWARE']/Key[@name='Microsoft']/Key[@name='EdgeUpdate']") | ForEach-Object { $_.ParentNode.RemoveChild($_) }

--- a/webex_webex-fedramp-arm64/VersionCheck.ps1
+++ b/webex_webex-fedramp-arm64/VersionCheck.ps1
@@ -1,0 +1,36 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Use this section to get the latest version 
+# either from the vendor website or the downloaded installer file
+
+# Get installer link for latest version
+$DownloadLink = "https://binaries.webex.com/WebexOfclDesktop-Win-Arm-64-Gold/Webex_en.msi"
+
+# Name of the downloaded installer file
+$InstallerName = "Webex_en.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = Get-MsiProductVersion "$Installer"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/zoomvideocommunications_zoom-arm64/BuildTurboImage.ps1
+++ b/zoomvideocommunications_zoom-arm64/BuildTurboImage.ps1
@@ -1,0 +1,108 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Zoom Video Communications"
+$AppDesc = "Zoom's secure, reliable video platform powers all of your communication needs, including meetings, chat, phone, webinars, and online events."
+$AppName = "Zoom ARM64"
+$VendorURL = "https://zoom.us/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# Get installer link for latest version
+$DownloadLink = "https://zoom.us/client/latest/ZoomInstallerFull.msi?archType=winarm64"
+
+# Name of the downloaded installer file
+$InstallerName = "ZoomInstallerFull.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess "msiexec.exe" "/I $Installer ALLUSERS=1 /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+
+$InstalledVersion = GetVersionFromRegistry "Zoom"
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/zoomvideocommunications_zoom-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/zoomvideocommunications_zoom-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,29 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+# Configure vm settings
+$VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
+$VirtualizationSettings.handleExplorerShellEx = [string]$true
+
+###################
+# Edit Services #
+###################
+
+$Services = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("Services")
+
+## Turn off AutoLoad for ZoomCptService
+# Null-guarded: arm64 captures don't always register the same services as x64
+$ZoomCptService = $Services.SelectSingleNode("Service[@name='ZoomCptService']")
+if ($ZoomCptService) { $ZoomCptService.start = "LoadOnDemand" }
+
+
+#################
+# Edit Registry #
+#################
+## NOTE: Beware of case sensitivity when making registry changes.  eg. The registry value type "String" requires an upper-case 'S'
+##       When specifying a registry value, "OpenWithProgids" is different from "OpenWithProgIds"
+
+# Set Hide isolation on HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce\zoommsirepair to prevent MSI healing
+# Null-guarded: arm64 captures don't always produce the same registry tree as x64
+$ZoomMsiRepair = $Registry.SelectSingleNode("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Microsoft']/Key[@name='Windows']/Key[@name='CurrentVersion']/Key[@name='RunOnce']/Value[@name='zoommsirepair']")
+if ($ZoomMsiRepair) { $ZoomMsiRepair.isolation = "Hide" }

--- a/zoomvideocommunications_zoom-arm64/VersionCheck.ps1
+++ b/zoomvideocommunications_zoom-arm64/VersionCheck.ps1
@@ -1,0 +1,30 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# Get installer link for latest version
+$DownloadLink = "https://zoom.us/client/latest/ZoomInstallerFull.msi?archType=winarm64"
+$InstallerName = "ZoomInstallerFull.msi"
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = Get-MsiProductVersion "$Installer"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}

--- a/zoomvideocommunications_zoom-fedramp-arm64/BuildTurboImage.ps1
+++ b/zoomvideocommunications_zoom-fedramp-arm64/BuildTurboImage.ps1
@@ -1,0 +1,111 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Import,  # If -Import is $true the image will be imported after built
+    [Parameter(Mandatory=$false)]
+    [string]$PushURL,    # If -Push is a URL, the image will be pushed to the Turbo Server
+    [Parameter(Mandatory=$false)]
+    [string]$ApiKey   # If -ApiKey is provided it will be used for the image push
+)
+
+## This script will download the latest installer and create a Turbo SVM image in @DESKTOP@\Package\TurboCapture.
+## The script is logged to @DESKTOP@\Package\Log.
+## The turbo project and build are saved  to @DESKTOP@\Package\TurboCapture.
+## Usage:
+## Run this script from an elevated cmd prompt: Powershell -ExecutionPolicy Bypass -File <path>\scriptname.ps1
+## Required:  You must have your Turbo Studio license in a "License.txt" file in an "Include" folder in the same folder as this script.
+## Required:  You must have the "GlobalBuildScript.ps1" file in an "Include" folder in the same folder as this script.
+## Required:  Any files used to customize the configuration should be a "Support Files" folder located in the same folder as this script.
+
+$scriptPath = $PSScriptRoot  # The folder path the script was launched from
+$GlobalScriptPath = Join-Path -Path $scriptPath -ChildPath "..\!include\GlobalBuildScript.ps1"  #Get the path to the GlobalBuildScript.ps1
+. $GlobalScriptPath  # Include the script that contains global variables and functions
+$SupportFiles = "$scriptPath\SupportFiles"  # The folder path contains files specific to this application build
+
+# Check if the current script is running with elevated privileges
+$elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# If not running with elevated privileges, Log and Exit
+if (-not $elevated) {
+   WriteLog "This script must run elevated.  Please re-run as Administrator"
+    # Exit the current script
+    exit
+}
+
+###################################
+## Define app specific variables ##
+###################################
+# These values will used to set the Metadata for the turbo image.
+
+$HubOrg = (Split-Path $scriptPath -Leaf) -replace '_', '/' # Set the repo name based on the folder path of the script assuming the folder is vendor_appname
+$Vendor = "Zoom Video Communications"
+$AppDesc = "Zoom's secure, reliable video platform powers all of your communication needs, including meetings, chat, phone, webinars, and online events."
+$AppName = "Zoom for Government ARM64"
+$VendorURL = "https://zoom.us/"
+
+########################################
+## Compare Hub Version to Web Version ##
+########################################
+CheckHubVersion
+
+##########################################
+## Download latest version of installer ##
+##########################################
+WriteLog "Downloading the latest MSI installer."
+
+# The x64 variant scrapes zoomgov.com/download/admin via the turbo/headless-extractor
+# image, but Turbo containers do not run on the Windows-on-ARM capture VMs. Use the
+# direct latest-client endpoint instead (the same link the admin download page resolves to).
+$DownloadLink = "https://zoomgov.com/client/latest/ZoomInstallerFull.msi?archType=winarm64"
+
+# Name of the downloaded installer file
+$InstallerName = "ZoomInstallerFull.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$InstalledVersion = Get-MsiProductVersion "$Installer"
+$InstalledVersion = RemoveTrailingZeros "$InstalledVersion"
+
+#########################
+## Start Turbo Capture ##
+#########################
+
+StartTurboCapture
+
+#############################
+## Install the application ##
+#############################
+WriteLog "Installing the application."
+
+$ProcessExitCode = RunProcess "msiexec.exe" "/I $Installer ALLUSERS=1 /qn" $True
+CheckForError "Checking process exit code:" 0 $ProcessExitCode $True # Fail on install error
+
+################################
+## Customize the application  ##
+################################
+WriteLog "Performing post-install customizations."
+
+
+#########################
+## Stop Turbo Capture  ##
+#########################
+
+StopTurboCapture
+
+######################
+## Customize XAPPL  ##
+######################
+
+CustomizeTurboXappl "$SupportFiles\PostCaptureModifications.ps1"  # Helper script for XML changes to Xappl"
+
+#########################
+## Build Turbo Image   ##
+#########################
+
+BuildTurboSvmImage
+
+########################
+## Push Turbo Image   ##
+########################
+
+PushImage $InstalledVersion
+

--- a/zoomvideocommunications_zoom-fedramp-arm64/SupportFiles/PostCaptureModifications.ps1
+++ b/zoomvideocommunications_zoom-fedramp-arm64/SupportFiles/PostCaptureModifications.ps1
@@ -1,0 +1,29 @@
+$PostCaptureFunctionsPath = Join-Path -Path $scriptPath -ChildPath "..\!include\PostCaptureFunctions.ps1"
+. $PostCaptureFunctionsPath  # Include the script that contains post capture functions
+
+# Configure vm settings
+$VirtualizationSettings = $xappl.Configuration.SelectSingleNode("VirtualizationSettings")
+$VirtualizationSettings.handleExplorerShellEx = [string]$true
+
+###################
+# Edit Services #
+###################
+
+$Services = $xappl.Configuration.Layers.SelectSingleNode("Layer[@name='Default']").SelectSingleNode("Services")
+
+## Turn off AutoLoad for ZoomCptService
+# Null-guarded: arm64 captures don't always register the same services as x64
+$ZoomCptService = $Services.SelectSingleNode("Service[@name='ZoomCptService']")
+if ($ZoomCptService) { $ZoomCptService.start = "LoadOnDemand" }
+
+
+#################
+# Edit Registry #
+#################
+## NOTE: Beware of case sensitivity when making registry changes.  eg. The registry value type "String" requires an upper-case 'S'
+##       When specifying a registry value, "OpenWithProgids" is different from "OpenWithProgIds"
+
+# Set Hide isolation on HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce\zoommsirepair to prevent MSI healing
+# Null-guarded: arm64 captures don't always produce the same registry tree as x64
+$ZoomMsiRepair = $Registry.SelectSingleNode("Key[@name='@HKCU@']/Key[@name='Software']/Key[@name='Microsoft']/Key[@name='Windows']/Key[@name='CurrentVersion']/Key[@name='RunOnce']/Value[@name='zoommsirepair']")
+if ($ZoomMsiRepair) { $ZoomMsiRepair.isolation = "Hide" }

--- a/zoomvideocommunications_zoom-fedramp-arm64/VersionCheck.ps1
+++ b/zoomvideocommunications_zoom-fedramp-arm64/VersionCheck.ps1
@@ -1,0 +1,35 @@
+Function RunVersionCheck {
+
+#############################################
+## Get the current Hub version for the app ##
+#############################################
+
+$HubVersion = GetCurrentHubVersion $HubOrg
+
+#############################################
+## Get latest version from the vendor site ##
+#############################################
+
+# The x64 variant scrapes zoomgov.com/download/admin via the turbo/headless-extractor
+# image, but Turbo containers do not run on the Windows-on-ARM capture VMs. Use the
+# direct latest-client endpoint instead and read the version from the MSI.
+$DownloadLink = "https://zoomgov.com/client/latest/ZoomInstallerFull.msi?archType=winarm64"
+
+# Name of the downloaded installer file
+$InstallerName = "ZoomInstallerFull.msi"
+
+$Installer = DownloadInstaller $DownloadLink $DownloadPath $InstallerName
+
+$LatestWebVersion = Get-MsiProductVersion "$Installer"
+$LatestWebVersion = RemoveTrailingZeros "$LatestWebVersion"
+
+WriteLog "WebVersion=$LatestWebVersion"
+
+
+###########################################
+## Compare latest version to hub version ##
+###########################################
+
+Compare-Versions $HubVersion $LatestWebVersion #Script will exit if Hub version is the same or newer.
+
+}


### PR DESCRIPTION
## Summary

Adds arm64 build definitions for 18 apps, focused on business/corporate use. All 18 were captured on the win11-arm pool, pushed to applab.turboqa.net, and launch-tested on ARM64 hardware.

Each directory is a clone of its x64/neutral counterpart with arch-specific deltas only; every recipe resolves "latest" at capture time and has a working VersionCheck, so all 18 track new vendor releases through the nightly discovery run.

**Batch 1 — communication / base:** Teams (arm64 MSIX via fwlink 2196207), Zoom (`archType=winarm64`), Webex (Arm-64-Gold MSI), VC++ Redistributable (`vc_redist.arm64.exe`)

**Batch 2 — business / IT utilities:** LibreOffice (`Win_aarch64.msi`), PuTTY (wa64 MSI), Postman (`win_arm64` endpoint), Paint.NET (`winmsi.arm64.zip`), VLC (`winarm64` from download.videolan.org)

**Batch 3 — gov clients / Microsoft stack:** Zoom for Government, Webex for Government, Firefox ESR (aarch64 exe — no arm64 MSI exists), .NET SDK (direct download), SSMS 22 (VS-installer bootstrapper, first native arm64 GA), Temurin JRE LTS (newest-first aarch64 LTS walk)

**Batch 4 — utilities:** IrfanView + Plugins (official ARM64 zips), GIMP (unified installer, installs native arm64 on WoA)

## Notable arch-specific handling

- **WoA container limitation**: the winget and headless-extractor Turbo images don't run on Windows-on-ARM capture VMs — dotnet-sdk and zoom-fedramp use direct vendor downloads instead
- **vc_redist on WoA** reboots the VM under `/S` — all arm64 usages install with `/install /quiet /norestart` and treat exit 3010 as success
- **IrfanView ships ARM64EC** (reports x64 in PE headers by design, runs natively on ARM64); its arm64 silent installer exits 0 without installing, so both recipes install from the official zips
- **EdgeUpdate registry strip** (Webex family) covers the native hive in addition to WOW6432Node, since Edge/WebView2 are native on arm64
- All post-capture xappl node edits are null-guarded — arm64 captures don't always produce the same trees as x64
- vcredist additionally publishes a year tag (`2022`) with a guarded parse that handles the arm64 bundle-only uninstall entry

## Deliberately omitted

- **Edge / WebView2**: no ARM capture OS ships without them preinstalled (no Windows Server ARM64 exists; Win11 IoT LTSC 2024 includes Edge), and every arm64 host has native WebView2, so containerized apps use the host runtime
- **Inkscape**: vendor's arm64 release pages currently serve x64 artifacts
- **Blender**: capture requires GPU; GPU capacity repurposed
- **Adobe Reader, Power BI, Keeper, Foxit Reader, WinSCP** and others: no native arm64 builds as of 2026-07

## Test plan

- [x] All 18 captures green on the win11-arm pool with correct version tags
- [x] GUI apps launch-tested on ARM64 hardware (basic tasks verified)
- [x] SSMS rebuilt after first image defaulted to the VS Installer startup file; relaunch verified
- [x] IrfanView binaries verified ARM64EC via CHPE metadata (a plain PE arch check misreads them as x64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)